### PR TITLE
Add detailed combo descriptions with action scores and position break…

### DIFF
--- a/AI/MCTS
+++ b/AI/MCTS
@@ -459,17 +459,32 @@ class MCTS {
 
 	/*
 	 * Build a short description of a combo for debugging.
-	 * Format: "Item1→Item2→cell123" or "stay" if no actions
+	 * Format: "Item1(score)→Item2(score)→mv(cell:total=Dd+Pp+Gg+Tt+Ss)" or "stay"
+	 *
+	 * Position breakdown abbreviations:
+	 *   d = danger (negative dmg taken if enemies attack)
+	 *   p = proximity (penalty for nearby enemies)
+	 *   g = gravity (attraction/repulsion to priority targets)
+	 *   t = tactical (lock, CAC range, COVID bonuses)
+	 *   s = shield (value of keeping current shields)
 	 */
 	static string buildComboDesc(Combo combo) {
 		string desc = ""
 		for (Action a in combo.actions) {
 			if (desc != "") desc += "→"
-			desc += a.item.name
+			desc += a.item.name + "(" + round(a.score!) + ")"
 		}
 		if (combo.finalPosition) {
 			if (desc != "") desc += "→"
-			desc += "c" + combo.finalPosition!.cell.id
+			Position p = combo.finalPosition!
+			desc += "mv(" + p.cell.id + ":"
+			desc += round(p.score) + "="
+			desc += round(-p.dmg) + "d"
+			desc += (p.proximityScore >= 0 ? "+" : "") + round(p.proximityScore) + "p"
+			desc += (p.gravityScore >= 0 ? "+" : "") + round(p.gravityScore) + "g"
+			desc += (p.tacticalScore >= 0 ? "+" : "") + round(p.tacticalScore) + "t"
+			desc += (p.shieldScore >= 0 ? "+" : "") + round(p.shieldScore) + "s"
+			desc += ")"
 		}
 		if (desc == "") desc = "stay"
 		return desc


### PR DESCRIPTION
MCTS.buildComboDesc() now outputs:
- Action scores: item(score) for each action
- Position breakdown: mv(cell:total=Dd+Pp+Gg+Tt+Ss)
  - d = danger (enemy damage potential)
  - p = proximity (nearby enemy penalty)
  - g = gravity (target attraction/repulsion)
  - t = tactical (lock, CAC, COVID bonuses)
  - s = shield (value of kept shields)

Tampermonkey updates:
- New formatComboDesc() parser with colored score display
- Updated renderCombos(), renderOverview(), and logs view

Example output:
armor(491)→helmet(677)→protein(836)→mv(478:268=0d+0p-14g+0t+282s)