### PR TITLE
Add fight page support with side panel and cache system (v1.4.0)

### DIFF
--- a/AI/BattleState
+++ b/AI/BattleState
@@ -1,0 +1,183 @@
+/*
+ * BattleState - Combat context and team state
+ *
+ * Contains team composition, flags, ratios, and other contextual data
+ * that is computed once per turn and used by Scoring modifiers.
+ *
+ * The refresh() method optimizes by combining multiple iterations into fewer loops.
+ *
+ * Used by: Scoring, ScoringModifiers, MapPosition
+ */
+class BattleState {
+
+	// === Team Composition ===
+	static integer countFire = 0      // ally fire bulbs
+	static integer countMetal = 0     // ally metallic bulbs
+	static integer countHealer = 0    // ally healer bulbs
+	static integer countStrBulbs = 0  // ally offensive bulbs (fire + iced + lightning)
+
+	// === Team Flags ===
+	static boolean enemyHasStr = false // any enemy has STR >= 100
+	static boolean allyHasStr = false  // any ally has STR >= 100 (for vuln value)
+
+	// === Global State Ratios ===
+	static real ratioHP = 1.0    // sum(ally life) / sum(enemy life)
+	static real ratioCount = 1.0 // ally count / enemy count
+
+	// === Ally maxHP Range (for HPMAX modifier) ===
+	static integer minAllyMaxHP = 0
+	static integer maxAllyMaxHP = 0
+
+	// === Chip Readiness ===
+	// Ready chip counts per ally (0.5 for cooldown=1, 1.0 for cooldown=0)
+	static Map<integer, real> wsdReadyChips = [:] // entityId -> readyCount
+	static Map<integer, real> rstReadyChips = [:] // entityId -> readyCount
+
+	// === Ally Danger ===
+	static Map<Entity, real> allyDanger = [:] // [ally: expectedDamageBeforeTheirTurn]
+
+	/*
+	 * Refresh all battle state data.
+	 * Called once per turn before Scoring.refresh().
+	 *
+	 * Optimized: combines multiple loops into fewer iterations.
+	 */
+	static void refresh() {
+		// Reset all state
+		countFire = 0
+		countMetal = 0
+		countHealer = 0
+		countStrBulbs = 0
+		allyHasStr = false
+		enemyHasStr = false
+		wsdReadyChips = [:]
+		rstReadyChips = [:]
+		allyDanger = [:]
+		minAllyMaxHP = 999999
+		maxAllyMaxHP = 0
+
+		// === Combined ally loop ===
+		// Handles: bulb counting, allyHasStr flag, WSD/RST chips
+		real sumAllyLife = 0.0
+		integer allyLeekCount = 0
+
+		for (Entity entity in Fight.getAlliesAlive()) {
+			// Count bulb types
+			integer eType = EntityTypes.getEntityType(entity)
+			if (eType == EntityTypes.BULB_FIRE) {
+				countFire++
+				countStrBulbs++
+			} else if (eType == EntityTypes.BULB_ICED || eType == EntityTypes.BULB_LIGHTNING) {
+				countStrBulbs++
+			} else if (eType == EntityTypes.BULB_METALLIC) {
+				countMetal++
+			} else if (eType == EntityTypes.BULB_HEALER) {
+				countHealer++
+			}
+
+			// Check for ally with significant strength
+			if (!allyHasStr && entity.str >= 100) {
+				allyHasStr = true
+			}
+
+			// Count WSD/RST chips for this ally
+			integer entityId = entity.id
+			real wsdCount = 0.0
+			real rstCount = 0.0
+			for (Item item in entity.items) {
+				if (item.isWeap) continue
+				integer chipId = item.id
+
+				if (ScoringConfig.WSD_CHIPS[chipId]) {
+					integer cd = getCooldown(chipId, entityId)
+					if (cd == 0) wsdCount += 1.0
+					else if (cd == 1) wsdCount += 0.5
+				}
+				if (ScoringConfig.RST_CHIPS[chipId]) {
+					integer cd = getCooldown(chipId, entityId)
+					if (cd == 0) rstCount += 1.0
+					else if (cd == 1) rstCount += 0.5
+				}
+			}
+			wsdReadyChips[entityId] = wsdCount
+			rstReadyChips[entityId] = rstCount
+
+			// For leeks only: compute ratios and maxHP range
+			if (!entity.isBulb) {
+				sumAllyLife += entity.life
+				allyLeekCount++
+				if (entity.totalLife < minAllyMaxHP) minAllyMaxHP = entity.totalLife
+				if (entity.totalLife > maxAllyMaxHP) maxAllyMaxHP = entity.totalLife
+			}
+		}
+
+		// === Combined enemy loop ===
+		// Handles: enemyHasStr flag, enemy life sum
+		real sumEnemyLife = 0.0
+		integer enemyLeekCount = 0
+
+		for (Entity entity in Fight.getEnemiesAlive()) {
+			// Check for enemy with significant strength
+			if (!enemyHasStr && entity.str >= 100) {
+				enemyHasStr = true
+			}
+
+			// For leeks only: compute ratios
+			if (!entity.isBulb) {
+				sumEnemyLife += entity.life
+				enemyLeekCount++
+			}
+		}
+
+		// Compute ratios
+		ratioHP = (sumEnemyLife > 0) ? sumAllyLife / sumEnemyLife : 1.0
+		ratioCount = (enemyLeekCount > 0) ? (allyLeekCount * 1.0) / enemyLeekCount : 1.0
+	}
+
+	/*
+	 * Computes expected danger for an ally from enemies who play before them
+	 * Uses MapDanger's pre-computed damage maps
+	 * @param ally The ally entity
+	 * @return Expected damage the ally will take before their turn
+	 */
+	static real computeAllyDanger(Entity ally) {
+		real totalDanger = 0.0
+		// Get enemies who play before this ally
+		for (Entity entity in ally.entitiesWhoPlayBefore) {
+			if (entity.isFriend) continue // only enemies
+			// Check each offensive item the enemy has
+			Map<Item, Map<Cell, real>>? enemyMaps = MapDanger._map_entity_item_danger[entity]
+			if (enemyMaps == null) continue
+			integer tpLeft = entity.tp
+			for (Item item in entity.offensiveItems) {
+				Map<Cell, real>? itemMap = enemyMaps![item]
+				if (itemMap == null) continue
+				real? ratioDmg = itemMap![ally.cell]
+				if (ratioDmg == null || ratioDmg <= 0) continue
+				// Estimate damage from this item
+				real itemDmg = Damages.getDamage(entity, ally, item, ratioDmg!, null)
+				if (itemDmg > 0) {
+					integer uses = 0
+					while (item.cost <= tpLeft && uses < item.maxUse) {
+						totalDanger += itemDmg
+						tpLeft -= item.cost
+						uses++
+						if (item.haveCD) break
+					}
+				}
+			}
+		}
+		return totalDanger
+	}
+
+	/*
+	 * Compute ally danger for all allies (called after MapDanger is ready)
+	 */
+	static void computeAllAllyDanger() {
+		for (Entity entity in Fight.getAlliesAlive()) {
+			if (entity != Fight.self) {
+				allyDanger[entity] = computeAllyDanger(entity)
+			}
+		}
+	}
+}

--- a/AI/EntityCoefs
+++ b/AI/EntityCoefs
@@ -1,0 +1,149 @@
+/*
+ * EntityCoefs - Base coefficients for scoring by entity type
+ *
+ * Contains the coefficient tables for different entity types and the
+ * base coefficient lookup function. These values determine how much
+ * each stat matters for different entities (leeks, bulbs, turrets, etc.)
+ *
+ * Used by: Scoring
+ */
+class EntityCoefs {
+
+	// === Entity Type Coefficients ===
+	// Map: entityType -> (stat -> baseCoef)
+	// Positive values for allies, negated for enemies in getStatCoef()
+	// Bulb types have individual entries for fine-grained control
+	static Map<integer, Map<integer, real>> baseCoefs = [
+		ENTITY_LEEK: [
+			Stats.HP: 1.0, Stats.HPTIME: 1.0, Stats.HPMAX: 2.0,
+			Stats.DEBUFF: 1.0, Stats.ANTIDOTE: 1.0,
+			Stats.ABSSHIELD: 3.0, Stats.RELSHIELD: 6.0, Stats.DMGRETURN: 3.0,
+			Stats.STR: 1.0, Stats.MGC: 1.0, Stats.RST: 0.5,
+			Stats.WSD: 0.5, Stats.AGI: 0.5,
+			Stats.TP: 40.0, Stats.MP: 40.0, Stats.PWR: 1.0, Stats.KILL: 1.0
+		],
+		ENTITY_BULB: [ // Generic bulb fallback
+			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.1,
+			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
+			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
+			Stats.STR: 0.2, Stats.MGC: 0.2, Stats.RST: 0.1,
+			Stats.WSD: 0.1, Stats.AGI: 0.1,
+			Stats.TP: 4.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
+		],
+		EntityTypes.BULB_HEALER: [
+			Stats.HP: 0.6, Stats.HPTIME: 0.3, Stats.HPMAX: 0.15,
+			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.3,
+			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
+			Stats.STR: 0.0, Stats.MGC: 0.2, Stats.RST: 0.1,
+			Stats.WSD: 0.1, Stats.AGI: 0.1,
+			Stats.TP: 4.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
+		],
+		EntityTypes.BULB_WIZARD: [
+			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.2,
+			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
+			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
+			Stats.STR: 0.0, Stats.MGC: 0.2, Stats.RST: 0.1,
+			Stats.WSD: 0.1, Stats.AGI: 0.1,
+			Stats.TP: 6.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
+		],
+		EntityTypes.BULB_FIRE: [
+			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.15,
+			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
+			Stats.ABSSHIELD: 1.0, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
+			Stats.STR: 0.4, Stats.MGC: 0.2, Stats.RST: 0.1,
+			Stats.WSD: 0.1, Stats.AGI: 0.1,
+			Stats.TP: 5.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
+		],
+		EntityTypes.BULB_ICED: [
+			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.15,
+			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
+			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
+			Stats.STR: 0.4, Stats.MGC: 0.2, Stats.RST: 0.1,
+			Stats.WSD: 0.1, Stats.AGI: 0.1,
+			Stats.TP: 5.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
+		],
+		EntityTypes.BULB_LIGHTNING: [
+			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.18,
+			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
+			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
+			Stats.STR: 0.5, Stats.MGC: 0.2, Stats.RST: 0.1,
+			Stats.WSD: 0.1, Stats.AGI: 0.1,
+			Stats.TP: 5.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
+		],
+		EntityTypes.BULB_METALLIC: [
+			Stats.HP: 0.3, Stats.HPTIME: 0.1, Stats.HPMAX: 0.05,
+			Stats.DEBUFF: 0.1, Stats.ANTIDOTE: 0.1,
+			Stats.ABSSHIELD: 0.1, Stats.RELSHIELD: 0.1, Stats.DMGRETURN: 0.6,
+			Stats.STR: 0.0, Stats.MGC: 0.1, Stats.RST: 0.1,
+			Stats.WSD: 0.1, Stats.AGI: 0.1,
+			Stats.TP: 2.0, Stats.MP: 4.0, Stats.PWR: 0.1, Stats.KILL: 0.1
+		],
+		EntityTypes.BULB_ROCKY: [
+			Stats.HP: 0.4, Stats.HPTIME: 0.2, Stats.HPMAX: 0.1,
+			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
+			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
+			Stats.STR: 0.2, Stats.MGC: 0.2, Stats.RST: 0.1,
+			Stats.WSD: 0.1, Stats.AGI: 0.1,
+			Stats.TP: 2.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
+		],
+		EntityTypes.BULB_PUNY: [
+			Stats.HP: 0.2, Stats.HPTIME: 0.1, Stats.HPMAX: 0.05,
+			Stats.DEBUFF: 0.1, Stats.ANTIDOTE: 0.1,
+			Stats.ABSSHIELD: 0.3, Stats.RELSHIELD: 0.6, Stats.DMGRETURN: 0.3,
+			Stats.STR: 0.05, Stats.MGC: 0.1, Stats.RST: 0.05,
+			Stats.WSD: 0.05, Stats.AGI: 0.05,
+			Stats.TP: 1.0, Stats.MP: 2.0, Stats.PWR: 0.1, Stats.KILL: 0.05
+		],
+		ENTITY_TURRET: [
+			Stats.HP: 1.0, Stats.HPTIME: 1.0, Stats.HPMAX: 2.0,
+			Stats.DEBUFF: 1.0, Stats.ANTIDOTE: 1.0,
+			Stats.ABSSHIELD: 3.0, Stats.RELSHIELD: 6.0, Stats.DMGRETURN: 3.0,
+			Stats.STR: 1.0, Stats.MGC: 1.0, Stats.RST: 0.5,
+			Stats.WSD: 0.5, Stats.AGI: 0.5,
+			Stats.TP: 40.0, Stats.MP: 40.0, Stats.PWR: 1.0, Stats.KILL: 1.0
+		],
+		ENTITY_CHEST: [
+			Stats.HP: 1.0, Stats.HPTIME: 1.0, Stats.HPMAX: 2.0,
+			Stats.DEBUFF: 1.0, Stats.ANTIDOTE: 1.0,
+			Stats.ABSSHIELD: 3.0, Stats.RELSHIELD: 6.0, Stats.DMGRETURN: 3.0,
+			Stats.STR: 1.0, Stats.MGC: 1.0, Stats.RST: 0.5,
+			Stats.WSD: 0.5, Stats.AGI: 0.5,
+			Stats.TP: 40.0, Stats.MP: 40.0, Stats.PWR: 1.0, Stats.KILL: 1.0
+		],
+		ENTITY_MOB: [
+			Stats.HP: 1.0, Stats.HPTIME: 1.0, Stats.HPMAX: 2.0,
+			Stats.DEBUFF: 1.0, Stats.ANTIDOTE: 1.0,
+			Stats.ABSSHIELD: 3.0, Stats.RELSHIELD: 6.0, Stats.DMGRETURN: 3.0,
+			Stats.STR: 1.0, Stats.MGC: 1.0, Stats.RST: 0.5,
+			Stats.WSD: 0.5, Stats.AGI: 0.5,
+			Stats.TP: 40.0, Stats.MP: 40.0, Stats.PWR: 1.0, Stats.KILL: 1.0
+		]
+	]
+
+	/*
+	 * Returns coefficient for a stat based on entity type and allegiance
+	 * @param entity The entity to get coefficient for
+	 * @param stat The stat type (Stats.HP, Stats.STR, etc.)
+	 * @return Positive for allies, negative for enemies
+	 */
+	static real getStatCoef(Entity entity, integer stat) {
+		// Direct lookup by entity type, fallback to ENTITY_BULB for unknown bulb types
+		Map<integer, real>? coefs = baseCoefs[EntityTypes.getEntityType(entity)]
+		if (coefs == null) {
+			// Unknown type - use BULB as fallback for summons, LEEK otherwise
+			if (entity.isBulb) {
+				debugW("Unimplemented bulb type: " + entity.entityType + " (" + entity.name + ")")
+				coefs = baseCoefs[ENTITY_BULB]
+			} else {
+				coefs = baseCoefs[ENTITY_LEEK]
+			}
+		}
+		real base = coefs![stat]!
+
+		// KILL is inverted: killing enemy = good, losing ally = bad
+		if (stat == Stats.KILL) {
+			return entity.isFriend ? -base : base
+		}
+		return entity.isFriend ? base : -base
+	}
+}

--- a/AI/EntityTypes
+++ b/AI/EntityTypes
@@ -1,0 +1,48 @@
+/*
+ * EntityTypes - Bulb type detection and classification
+ *
+ * Provides extended entity type constants for bulbs (not provided by LeekScript)
+ * and utility functions to detect entity types from names.
+ *
+ * Used by: EntityCoefs, Scoring, ScoringModifiers
+ */
+class EntityTypes {
+
+	// === Bulb Type Constants ===
+	// Values chosen to not conflict with ENTITY_LEEK (0), ENTITY_BULB (1),
+	// ENTITY_TURRET (2), ENTITY_CHEST (3), ENTITY_MOB (4)
+	static integer BULB_HEALER = 101
+	static integer BULB_WIZARD = 102
+	static integer BULB_FIRE = 103
+	static integer BULB_ICED = 104
+	static integer BULB_LIGHTNING = 105
+	static integer BULB_METALLIC = 106
+	static integer BULB_ROCKY = 107
+	static integer BULB_PUNY = 108
+
+	/*
+	 * Detects bulb type from entity name
+	 * @param name The entity name (e.g. "fire_bulb", "healer_bulb")
+	 * @return Bulb type constant, or ENTITY_BULB if unknown
+	 */
+	static integer getBulbType(string name) {
+		if (name == "metallic_bulb") return BULB_METALLIC
+		if (name == "healer_bulb") return BULB_HEALER
+		if (name == "lightning_bulb") return BULB_LIGHTNING
+		if (name == "wizard_bulb") return BULB_WIZARD
+		if (name == "fire_bulb") return BULB_FIRE
+		if (name == "iced_bulb") return BULB_ICED
+		if (name == "rocky_bulb") return BULB_ROCKY
+		if (name == "puny_bulb") return BULB_PUNY
+		return ENTITY_BULB
+	}
+
+	/*
+	 * Gets the effective entity type using cached extendedType
+	 * @param entity The entity
+	 * @return Entity type (ENTITY_LEEK, BULB_FIRE, etc.)
+	 */
+	static integer getEntityType(Entity entity) {
+		return entity.extendedType
+	}
+}

--- a/AI/Scoring
+++ b/AI/Scoring
@@ -1,524 +1,126 @@
+/*
+ * Scoring - Main façade for action scoring system
+ *
+ * Provides cached coefficients and duration calculations for action evaluation.
+ * Contains getDynamicCoef() which uses ScoringModifiers for coefficient adjustments.
+ *
+ * Architecture:
+ * - ScoringConfig: ML-tunable constants and weights
+ * - EntityTypes: Entity type detection (bulbs, leeks, etc.)
+ * - EntityCoefs: Base coefficient tables per entity type
+ * - BattleState: Per-turn team state (composition, flags, ratios)
+ * - ScoringModifiers: Pure modifier functions
+ * - Scoring: This class - façade, caches, and getDynamicCoef
+ *
+ * Used by: Consequences, MapAction, AI, MCTS
+ */
 class Scoring {
-	static Map<Entity, Map<integer, real>> _cache_coef = [:] // [entity:[key:value]]
-	static Map<integer, integer> _cache_duration = [:] // [(rawDuration+1)*2 + turnOrderBit : effectiveDuration]
-	static Map<Entity, real> _allyDanger = [:] // [ally: expectedDamageBeforeTheirTurn]
 
-	// Bulb type constants (not provided by LeekScript, defined manually)
-	// Values chosen to not conflict with ENTITY_LEEK (0), ENTITY_BULB (1), ENTITY_TURRET (2), ENTITY_CHEST (3), ENTITY_MOB (4)
-	static integer BULB_HEALER = 101
-	static integer BULB_WIZARD = 102
-	static integer BULB_FIRE = 103
-	static integer BULB_ICED = 104
-	static integer BULB_LIGHTNING = 105
-	static integer BULB_METALLIC = 106
-	static integer BULB_ROCKY = 107
-	static integer BULB_PUNY = 108
+	// === Caches (recomputed each turn) ===
+	static Map<Entity, Map<integer, real>> _cache_coef = [:] // [entity:[stat:coef]]
+	static Map<integer, integer> _cache_duration = [:]       // [key:effectiveDuration]
+
+	// === Dynamic Position Weights (computed in refresh) ===
+	static real W_LOCK_BONUS = 1000.0         // bonus for locking enemy
+	static integer IDEAL_DIST_RANGED = -1     // calculated at first turn: self.mp + longest item range
 
 	/*
-	 * Detects bulb type from entity name
-	 * @param name The entity name (e.g. "fire_bulb", "healer_bulb")
-	 * @return Bulb type constant, or ENTITY_BULB if unknown
+	 * Initialize all scoring data for the current turn.
+	 * Delegates team state to BattleState, then computes local caches.
+	 * Called once per turn before action evaluation.
 	 */
-	static integer getBulbType(string name) {
-		if (name == "metallic_bulb") return BULB_METALLIC
-		if (name == "healer_bulb") return BULB_HEALER
-		if (name == "lightning_bulb") return BULB_LIGHTNING
-		if (name == "wizard_bulb") return BULB_WIZARD
-		if (name == "fire_bulb") return BULB_FIRE
-		if (name == "iced_bulb") return BULB_ICED
-		if (name == "rocky_bulb") return BULB_ROCKY
-		if (name == "puny_bulb") return BULB_PUNY
-		return ENTITY_BULB
+	static void refresh() {
+		// === Delegate team state computation to BattleState ===
+		BattleState.refresh()
+
+		// === Reset local caches ===
+		_cache_coef = [:]
+		_cache_duration = [:]
+
+		// === Compute dynamic position weights ===
+		// W_LOCK_BONUS: reduced when vulnerable (prioritize survival over locking)
+		boolean notShielded = Fight.self.absShield <= 0 && Fight.self.relShield <= 0
+		boolean notFullLife = Fight.self.life < Fight.self.totalLife
+		if ((notShielded && BattleState.enemyHasStr) || notFullLife) {
+			W_LOCK_BONUS = 500.0
+		} else {
+			W_LOCK_BONUS = 1000.0
+		}
+
+		// IDEAL_DIST_RANGED: calculated once at first turn, reduced every 5 turns
+		if (IDEAL_DIST_RANGED == -1) {
+			integer longestRange = 0
+			for (Item item in Fight.self.items) {
+				if (item.maxRange > longestRange) {
+					longestRange = item.maxRange
+				}
+			}
+			IDEAL_DIST_RANGED = Fight.self.mp + longestRange
+		}
+		if (getTurn() % 5 == 0) IDEAL_DIST_RANGED--
+
+		// === Pre-compute effective durations ===
+		// Key formula: (rawDuration + 1) * 2 + (sourceAfterTarget ? 1 : 0)
+		integer turnsLeft = ScoringConfig.MAX_FIGHT_TURNS - getTurn()
+		for (integer raw = -1; raw <= ScoringConfig.MAX_DURATION; raw++) {
+			integer base = raw == -1 ? turnsLeft : min(raw, turnsLeft)
+			base = min(base, ScoringConfig.MAX_DURATION)
+			// source plays before target → target gets full duration
+			_cache_duration[(raw + 1) * 2] = max(base, 0)
+			// source plays after target → target gets 1 less turn
+			_cache_duration[(raw + 1) * 2 + 1] = max(base - 1, 0)
+		}
+
+		// === Pre-compute base coefficients for all entities ===
+		for (Entity entity in Fight.getAllAlive()) {
+			_cache_coef[entity] = [:]
+			_cache_coef[entity]![Stats.HP] = EntityCoefs.getStatCoef(entity, Stats.HP)
+			_cache_coef[entity]![Stats.HPTIME] = EntityCoefs.getStatCoef(entity, Stats.HPTIME)
+			_cache_coef[entity]![Stats.HPMAX] = EntityCoefs.getStatCoef(entity, Stats.HPMAX)
+			_cache_coef[entity]![Stats.DEBUFF] = EntityCoefs.getStatCoef(entity, Stats.DEBUFF)
+			_cache_coef[entity]![Stats.ANTIDOTE] = EntityCoefs.getStatCoef(entity, Stats.ANTIDOTE)
+			_cache_coef[entity]![Stats.ABSSHIELD] = EntityCoefs.getStatCoef(entity, Stats.ABSSHIELD)
+			_cache_coef[entity]![Stats.RELSHIELD] = EntityCoefs.getStatCoef(entity, Stats.RELSHIELD)
+			_cache_coef[entity]![Stats.DMGRETURN] = EntityCoefs.getStatCoef(entity, Stats.DMGRETURN)
+			_cache_coef[entity]![Stats.STR] = EntityCoefs.getStatCoef(entity, Stats.STR)
+			_cache_coef[entity]![Stats.MGC] = EntityCoefs.getStatCoef(entity, Stats.MGC)
+			_cache_coef[entity]![Stats.RST] = EntityCoefs.getStatCoef(entity, Stats.RST)
+			_cache_coef[entity]![Stats.WSD] = EntityCoefs.getStatCoef(entity, Stats.WSD)
+			_cache_coef[entity]![Stats.AGI] = EntityCoefs.getStatCoef(entity, Stats.AGI)
+			_cache_coef[entity]![Stats.TP] = EntityCoefs.getStatCoef(entity, Stats.TP)
+			_cache_coef[entity]![Stats.MP] = EntityCoefs.getStatCoef(entity, Stats.MP)
+			_cache_coef[entity]![Stats.PWR] = EntityCoefs.getStatCoef(entity, Stats.PWR)
+			_cache_coef[entity]![Stats.KILL] = EntityCoefs.getStatCoef(entity, Stats.KILL)
+		}
 	}
 
 	/*
-	 * Gets the effective entity type, using getBulbType for bulbs
+	 * Returns cached base coefficient for an entity and stat
 	 * @param entity The entity
-	 * @return Entity type (ENTITY_LEEK, BULB_FIRE, etc.)
+	 * @param key The stat type (Stats.HP, Stats.STR, etc.)
+	 * @return Base coefficient (positive for allies, negative for enemies)
 	 */
-	static integer getEntityType(Entity entity) {
-		if (entity.isBulb) return getBulbType(entity.name)
-		return entity.entityType
-	}
-
-	// Team composition (computed in refresh)
-	static integer _countFire = 0      // ally fire bulbs
-	static integer _countMetal = 0     // ally metallic bulbs
-	static integer _countHealer = 0    // ally healer bulbs
-	static integer _countStrBulbs = 0  // ally offensive bulbs (fire + iced + lightning)
-	static boolean _enemyHasStr = false // any enemy has STR >= 100
-	static boolean _allyHasStr = false  // any ally has STR >= 100 (for vuln value)
-
-	// Global state ratios (computed in refresh)
-	static real _ratioHP = 1.0    // sum(ally life) / sum(enemy life)
-	static real _ratioCount = 1.0 // ally count / enemy count
-
-	// Chip lists for WSD and RST modifiers
-	static Array<integer> WSD_CHIPS = [CHIP_ELEVATION, CHIP_CURE, CHIP_VACCINE, CHIP_ARMORING, CHIP_REMISSION]
-	static Array<integer> RST_CHIPS = [CHIP_HELMET, CHIP_SHIELD, CHIP_ARMOR, CHIP_WALL, CHIP_FORTRESS]
-
-	// Ready chip counts per ally (0.5 for cooldown=1, 1.0 for cooldown=0)
-	static Map<integer, real> _wsdReadyChips = [:] // entityId -> readyCount
-	static Map<integer, real> _rstReadyChips = [:] // entityId -> readyCount
-
-	// Ally maxHP range (for HPMAX modifier)
-	static integer _minAllyMaxHP = 0
-	static integer _maxAllyMaxHP = 0
-
-	static real CANDIE_MODIFIER = 10.0 // massive boost when ally might die
-	static real CANDIE_THRESHOLD = 0.8 // ally.hp < danger * threshold → canDie
-	static real IGNORE_DANGER_RATIO = 0.1 // ignore damage < 10% of current life
-
-	static integer KILL_VALUE = 2000
-	static integer DEATH_VALUE = -2000
-	static integer MAX_FIGHT_TURNS = 66
-	static integer MAX_DURATION = 8 // max index in duration_mitigation maps
-
-	// === Entity Type Coefficients ===
-	// Map: entityType -> (stat -> baseCoef)
-	// Positive values for allies, negated for enemies in getStatCoef()
-	// Bulb types have individual entries for fine-grained control
-	static Map<integer, Map<integer, real>> baseCoefs = [
-		ENTITY_LEEK: [
-			Stats.HP: 1.0, Stats.HPTIME: 1.0, Stats.HPMAX: 2.0,
-			Stats.DEBUFF: 1.0, Stats.ANTIDOTE: 1.0,
-			Stats.ABSSHIELD: 3.0, Stats.RELSHIELD: 6.0, Stats.DMGRETURN: 3.0,
-			Stats.STR: 1.0, Stats.MGC: 1.0, Stats.RST: 0.5,
-			Stats.WSD: 0.5, Stats.AGI: 0.5,
-			Stats.TP: 40.0, Stats.MP: 40.0, Stats.PWR: 1.0, Stats.KILL: 1.0
-		],
-		ENTITY_BULB: [ // Generic bulb fallback
-			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.1,
-			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
-			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
-			Stats.STR: 0.2, Stats.MGC: 0.2, Stats.RST: 0.1,
-			Stats.WSD: 0.1, Stats.AGI: 0.1,
-			Stats.TP: 4.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
-		],
-		BULB_HEALER: [
-			Stats.HP: 0.6, Stats.HPTIME: 0.3, Stats.HPMAX: 0.15,
-			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.3,
-			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
-			Stats.STR: 0.0, Stats.MGC: 0.2, Stats.RST: 0.1,
-			Stats.WSD: 0.1, Stats.AGI: 0.1,
-			Stats.TP: 4.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
-		],
-		BULB_WIZARD: [
-			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.2,
-			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
-			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
-			Stats.STR: 0.0, Stats.MGC: 0.2, Stats.RST: 0.1,
-			Stats.WSD: 0.1, Stats.AGI: 0.1,
-			Stats.TP: 6.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
-		],
-		BULB_FIRE: [
-			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.15,
-			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
-			Stats.ABSSHIELD: 1.0, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
-			Stats.STR: 0.4, Stats.MGC: 0.2, Stats.RST: 0.1,
-			Stats.WSD: 0.1, Stats.AGI: 0.1,
-			Stats.TP: 5.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
-		],
-		BULB_ICED: [
-			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.15,
-			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
-			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
-			Stats.STR: 0.4, Stats.MGC: 0.2, Stats.RST: 0.1,
-			Stats.WSD: 0.1, Stats.AGI: 0.1,
-			Stats.TP: 5.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
-		],
-		BULB_LIGHTNING: [
-			Stats.HP: 0.5, Stats.HPTIME: 0.2, Stats.HPMAX: 0.18,
-			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
-			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
-			Stats.STR: 0.5, Stats.MGC: 0.2, Stats.RST: 0.1,
-			Stats.WSD: 0.1, Stats.AGI: 0.1,
-			Stats.TP: 5.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
-		],
-		BULB_METALLIC: [
-			Stats.HP: 0.3, Stats.HPTIME: 0.1, Stats.HPMAX: 0.05,
-			Stats.DEBUFF: 0.1, Stats.ANTIDOTE: 0.1,
-			Stats.ABSSHIELD: 0.1, Stats.RELSHIELD: 0.1, Stats.DMGRETURN: 0.6,
-			Stats.STR: 0.0, Stats.MGC: 0.1, Stats.RST: 0.1,
-			Stats.WSD: 0.1, Stats.AGI: 0.1,
-			Stats.TP: 2.0, Stats.MP: 4.0, Stats.PWR: 0.1, Stats.KILL: 0.1
-		],
-		BULB_ROCKY: [
-			Stats.HP: 0.4, Stats.HPTIME: 0.2, Stats.HPMAX: 0.1,
-			Stats.DEBUFF: 0.2, Stats.ANTIDOTE: 0.2,
-			Stats.ABSSHIELD: 0.6, Stats.RELSHIELD: 1.2, Stats.DMGRETURN: 0.6,
-			Stats.STR: 0.2, Stats.MGC: 0.2, Stats.RST: 0.1,
-			Stats.WSD: 0.1, Stats.AGI: 0.1,
-			Stats.TP: 2.0, Stats.MP: 4.0, Stats.PWR: 0.2, Stats.KILL: 0.2
-		],
-		BULB_PUNY: [
-			Stats.HP: 0.2, Stats.HPTIME: 0.1, Stats.HPMAX: 0.05,
-			Stats.DEBUFF: 0.1, Stats.ANTIDOTE: 0.1,
-			Stats.ABSSHIELD: 0.3, Stats.RELSHIELD: 0.6, Stats.DMGRETURN: 0.3,
-			Stats.STR: 0.05, Stats.MGC: 0.1, Stats.RST: 0.05,
-			Stats.WSD: 0.05, Stats.AGI: 0.05,
-			Stats.TP: 1.0, Stats.MP: 2.0, Stats.PWR: 0.1, Stats.KILL: 0.05
-		],
-		ENTITY_TURRET: [
-			Stats.HP: 1.0, Stats.HPTIME: 1.0, Stats.HPMAX: 2.0,
-			Stats.DEBUFF: 1.0, Stats.ANTIDOTE: 1.0,
-			Stats.ABSSHIELD: 3.0, Stats.RELSHIELD: 6.0, Stats.DMGRETURN: 3.0,
-			Stats.STR: 1.0, Stats.MGC: 1.0, Stats.RST: 0.5,
-			Stats.WSD: 0.5, Stats.AGI: 0.5,
-			Stats.TP: 40.0, Stats.MP: 40.0, Stats.PWR: 1.0, Stats.KILL: 1.0
-		],
-		ENTITY_CHEST: [
-			Stats.HP: 1.0, Stats.HPTIME: 1.0, Stats.HPMAX: 2.0,
-			Stats.DEBUFF: 1.0, Stats.ANTIDOTE: 1.0,
-			Stats.ABSSHIELD: 3.0, Stats.RELSHIELD: 6.0, Stats.DMGRETURN: 3.0,
-			Stats.STR: 1.0, Stats.MGC: 1.0, Stats.RST: 0.5,
-			Stats.WSD: 0.5, Stats.AGI: 0.5,
-			Stats.TP: 40.0, Stats.MP: 40.0, Stats.PWR: 1.0, Stats.KILL: 1.0
-		],
-		ENTITY_MOB: [
-			Stats.HP: 1.0, Stats.HPTIME: 1.0, Stats.HPMAX: 2.0,
-			Stats.DEBUFF: 1.0, Stats.ANTIDOTE: 1.0,
-			Stats.ABSSHIELD: 3.0, Stats.RELSHIELD: 6.0, Stats.DMGRETURN: 3.0,
-			Stats.STR: 1.0, Stats.MGC: 1.0, Stats.RST: 0.5,
-			Stats.WSD: 0.5, Stats.AGI: 0.5,
-			Stats.TP: 40.0, Stats.MP: 40.0, Stats.PWR: 1.0, Stats.KILL: 1.0
-		],
-	]
-
-	/*
-	 * Returns coefficient for a stat based on entity type and allegiance
-	 * @param entity The entity to get coefficient for
-	 * @param stat The stat type (Stats.HP, Stats.STR, etc.)
-	 * @return Positive for allies, negative for enemies
-	 */
-	static real getStatCoef(Entity entity, integer stat) {
-		// Direct lookup by entity type, fallback to ENTITY_BULB for unknown bulb types
-		Map<integer, real>? coefs = baseCoefs[getEntityType(entity)]
-		if (coefs == null) {
-			// Unknown type - use BULB as fallback for summons, LEEK otherwise
-			if (entity.isBulb) {
-				debugW("Unimplemented bulb type: " + entity.entityType + " (" + entity.name + ")")
-				coefs = baseCoefs[ENTITY_BULB]
-			} else {
-				coefs = baseCoefs[ENTITY_LEEK]
-			}
-		}
-		real base = coefs![stat]!
-
-		// KILL is inverted: killing enemy = good, losing ally = bad
-		if (stat == Stats.KILL) {
-			return entity.isFriend ? -base : base
-		}
-		return entity.isFriend ? base : -base
+	static real getCoef(Entity entity, integer key) {
+		return _cache_coef[entity]![key]!
 	}
 
 	/*
-	 * Computes lifeRatio modifier: more valuable to heal/damage low HP targets
-	 *
-	 * ALLY formula: min(2/lifeRatio - 1, 10.0) - aggressive curve for healing urgency
-	 * | lifeRatio | modifier | meaning                          |
-	 * |-----------|----------|----------------------------------|
-	 * | 1.00      | 1.0      | full HP → no bonus               |
-	 * | 0.80      | 1.5      | slightly hurt → small boost      |
-	 * | 0.67      | 2.0      | 2/3 HP → double value            |
-	 * | 0.50      | 3.0      | half HP → triple value           |
-	 * | 0.40      | 4.0      | hurt → 4x value                  |
-	 * | 0.25      | 7.0      | critical → 7x value              |
-	 * | 0.20      | 9.0      | near death → 9x value            |
-	 * | ≤0.18     | 10.0     | dying → capped at 10x            |
-	 *
-	 * ENEMY formula: 10 - 8 * lifeRatio - linear from 2 (full) to 10 (dead)
-	 * | lifeRatio | modifier | meaning                          |
-	 * |-----------|----------|----------------------------------|
-	 * | 1.00      | 2.0      | full HP → base priority          |
-	 * | 0.75      | 4.0      | wounded → increasing priority    |
-	 * | 0.50      | 6.0      | half HP → 6x value               |
-	 * | 0.25      | 8.0      | low HP → 8x value                |
-	 * | 0.10      | 9.2      | critical → near max              |
-	 * | 0.00      | 10.0     | dead → capped at 10x             |
+	 * Checks if an ally might die before their next turn
+	 * Uses cached danger and current HP (accounting for consequences)
+	 * @param entity The ally to check
+	 * @param consequences Optional consequences for current HP calculation
+	 * @return true if entity might die before they can act
 	 */
-	static real getLifeRatioModifier(Entity entity) {
-		real lifeRatio = entity.life / entity.totalLife
-		if (lifeRatio <= 0.0) return 10.0 // safety: dead or invalid
-
-		if (entity.isFriend) {
-			// Ally: aggressive curve - prioritize healing low HP allies
-			return min(2.0 / lifeRatio - 1.0, 10.0)
-		} else {
-			// Enemy: linear curve from 2 (full HP) to 10 (dead)
-			return 10.0 - 8.0 * lifeRatio
-		}
-	}
-
-	// Precomputed: 0.5 / log(301) ≈ 0.0876
-	static real LEVEL_RATIO_SCALE = 0.0876
-
-	/*
-	 * Computes levelRatio modifier: more valuable to buff high-level allies
-	 * Formula: 1.0 + 0.5 * log(targetLevel / selfLevel) / log(301)
-	 *
-	 * Scoring evolution (logarithmic, symmetric):
-	 * | level ratio | modifier | meaning                          |
-	 * |-------------|----------|----------------------------------|
-	 * | 1/301       | 0.50     | buffing lvl 1 as lvl 301 → half  |
-	 * | 1/10        | 0.80     | buffing much lower level         |
-	 * | 1/2         | 0.94     | buffing slightly lower level     |
-	 * | 1           | 1.00     | same level → no change           |
-	 * | 2           | 1.06     | buffing slightly higher level    |
-	 * | 10          | 1.20     | buffing much higher level        |
-	 * | 301         | 1.50     | buffing lvl 301 as lvl 1 → 1.5x  |
-	 */
-	static real getLevelRatioModifier(Entity entity) {
-		integer selfLevel = Fight.self.level
-		if (selfLevel <= 0) return 1.0 // safety
-		real ratio = entity.level / selfLevel
-		if (ratio <= 0.0) return 0.5 // safety: clamp to minimum
-		return max(0.5, min(1.5, 1.0 + LEVEL_RATIO_SCALE * log(ratio)))
+	static boolean canDie(Entity entity, Consequences? consequences) {
+		real? danger = BattleState.allyDanger[entity]
+		if (danger == null) return false
+		integer currentHP = entity.getCurrentHP(consequences)
+		return currentHP < danger! * ScoringConfig.CANDIE_THRESHOLD
 	}
 
 	/*
-	 * Computes STR/MGC scaling modifier based on current stat level
-	 * Peak value at 1000, diminishing returns above
-	 *
-	 * Scoring evolution:
-	 * | Current stat | modifier | meaning                        |
-	 * |--------------|----------|--------------------------------|
-	 * | 0            | 0.5      | no stat, low value to boost    |
-	 * | 500          | 1.0      | mid stat                       |
-	 * | 1000         | 1.5      | peak value (scales best)       |
-	 * | 1500         | 1.0      | diminishing returns            |
-	 * | 2000+        | 0.5      | very high, minimal benefit     |
-	 */
-	static real getStatScalingModifier(integer currentStat) {
-		if (currentStat <= 0) return 0.5
-		if (currentStat <= 1000) {
-			// Linear 0.5 → 1.5 over 0 → 1000
-			return 0.5 + (currentStat / 1000.0)
-		}
-		if (currentStat <= 2000) {
-			// Linear 1.5 → 0.5 over 1000 → 2000
-			return 1.5 - ((currentStat - 1000) / 1000.0)
-		}
-		return 0.5
-	}
-
-	/*
-	 * Computes maxHP comparison modifier for HPMAX stat
-	 * Low maxHP allies benefit more from HPMAX boosts
-	 *
-	 * Scoring evolution:
-	 * | Entity maxHP position | modifier | meaning                    |
-	 * |-----------------------|----------|----------------------------|
-	 * | lowest among allies   | 1.5      | needs HP boost most        |
-	 * | average               | 1.0      | neutral                    |
-	 * | highest among allies  | 0.5      | doesn't need it as much    |
-	 *
-	 * @param entity The ally entity
-	 * @return Multiplier for HPMAX coefficient (0.5 to 1.5)
-	 */
-	static real getMaxHPComparisonModifier(Entity entity) {
-		if (_maxAllyMaxHP <= _minAllyMaxHP) return 1.0  // all same or invalid
-
-		// Where does this entity fall in the range? (0 = lowest, 1 = highest)
-		real position = (entity.totalLife - _minAllyMaxHP) * 1.0 / (_maxAllyMaxHP - _minAllyMaxHP)
-
-		// Invert: low maxHP → high modifier (1.5), high maxHP → low modifier (0.5)
-		return 1.5 - position
-	}
-
-	/*
-	 * Gets the chip readiness modifier for WSD or RST
-	 * Chips at cooldown 0 count as 1.0, cooldown 1 counts as 0.5
-	 *
-	 * Scoring evolution:
-	 * | Ready count | modifier | meaning                        |
-	 * |-------------|----------|--------------------------------|
-	 * | 0           | 0.5      | no chips ready, low value      |
-	 * | 0.5         | 0.75     | one chip at cooldown 1         |
-	 * | 1           | 1.0      | one chip ready                 |
-	 * | 2           | 1.25     | two chips ready                |
-	 * | 3+          | 1.5      | many chips ready               |
-	 *
-	 * @param entity The ally entity
-	 * @param stat Stats.WSD or Stats.RST
-	 * @return Multiplier for stat coefficient
-	 */
-	static real getChipReadyModifier(Entity entity, integer stat) {
-		real readyCount = 0.0
-		if (stat == Stats.WSD) {
-			readyCount = _wsdReadyChips[entity.id]  // null coerces to 0
-		} else if (stat == Stats.RST) {
-			readyCount = _rstReadyChips[entity.id]  // null coerces to 0
-		}
-
-		if (readyCount <= 0) return 0.5
-		if (readyCount <= 1) {
-			// Linear 0.5 → 1.0 over 0 → 1
-			return 0.5 + 0.5 * readyCount
-		}
-		if (readyCount <= 3) {
-			// Linear 1.0 → 1.5 over 1 → 3
-			return 1.0 + 0.25 * (readyCount - 1)
-		}
-		return 1.5
-	}
-
-	/*
-	 * Computes winning modifier based on global HP and count ratios
-	 * Adjusts how much we care about ally HP/HPTIME based on match state
-	 *
-	 * Note: Individual danger (low HP, no shields, canDie) is handled by
-	 * other modifiers - this is ONLY about global winning/losing state.
-	 *
-	 * Formula: modifier = 1.5 - 0.5 * combined, clamped to [0.5, 1.5]
-	 * where combined = (ratioHP + ratioCount) / 2
-	 *
-	 * Scoring evolution:
-	 * | ratioHP | ratioCount | combined | modifier | meaning              |
-	 * |---------|------------|----------|----------|----------------------|
-	 * | 2.0     | 2.0        | 2.0      | 0.5      | winning → relax      |
-	 * | 1.5     | 1.5        | 1.5      | 0.75     | ahead                |
-	 * | 1.0     | 1.0        | 1.0      | 1.0      | even → neutral       |
-	 * | 0.5     | 0.5        | 0.5      | 1.25     | behind               |
-	 * | 0.33    | 0.33       | 0.33     | 1.5      | losing → prioritize  |
-	 *
-	 * @return Multiplier for ally HP/HPTIME coefficients
-	 */
-	static real getWinningModifier() {
-		real combined = (_ratioHP + _ratioCount) / 2.0
-		real modifier = 1.5 - 0.5 * combined
-		return max(0.5, min(1.5, modifier))
-	}
-
-	/*
-	 * Computes shield status modifier based on current shield levels
-	 * More valuable to shield unshielded allies / remove shields from unshielded enemies
-	 *
-	 * Scoring evolution (for ALLIES):
-	 * | Entity      | Current Shield | enemyHasStr | Modifier | Rationale                  |
-	 * |-------------|----------------|-------------|----------|----------------------------|
-	 * | LEEK        | 0              | yes         |     3.0x | urgent need for shields    |
-	 * | LEEK        | ≤80            | yes         |     2.0x | low shields, STR incoming  |
-	 * | LEEK        | any            | no          |     1.0x | no physical threat         |
-	 * | FIRE_BULB   | 0              | any         |     2.0x | fire bulb needs protection |
-	 * | other       | any            | any         |     1.0x | default                    |
-	 *
-	 * Scoring evolution (for ENEMIES - inverted logic):
-	 * | Current Shield | Modifier | Rationale                              |
-	 * |----------------|----------|----------------------------------------|
-	 * | 0              |     0.5x | already unshielded, less urgent        |
-	 * | ≤100           |     1.5x | low shields, worth removing            |
-	 * | >100           |     1.0x | normal priority                        |
-	 *
-	 * @param entity The entity
-	 * @param stat ABSSHIELD or RELSHIELD
-	 * @return Multiplier based on current shield status
-	 */
-	static real getShieldStatusModifier(Entity entity, integer stat) {
-		if (stat != Stats.ABSSHIELD && stat != Stats.RELSHIELD) return 1.0
-
-		// Get current shield value
-		integer currentShield = (stat == Stats.ABSSHIELD) ? entity.absShield : entity.relShield
-
-		if (entity.isFriend) {
-			// Ally: boost when unshielded and enemy has STR
-			integer eType = getEntityType(entity)
-
-			// Fire bulb with no shields: extra boost
-			if (eType == BULB_FIRE && currentShield <= 0) {
-				return 2.0
-			}
-
-			// Leek with low/no shields when enemy has STR
-			if (eType == ENTITY_LEEK && _enemyHasStr) {
-				if (currentShield <= 0) return 3.0
-				if (currentShield <= 80) return 2.0
-			}
-		} else {
-			// Enemy: vuln value - based on whether WE have STR to exploit it
-			if (!_allyHasStr) {
-				return 0.5  // No STR, vuln is less valuable
-			}
-
-			// Smooth scaling from 2x (at 0) to 1x (at threshold)
-			// ABSSHIELD: 0-100 range, RELSHIELD: 0-20 range
-			if (stat == Stats.ABSSHIELD) {
-				if (currentShield <= 0) return 2.0
-				if (currentShield >= 100) return 1.0
-				return 2.0 - (currentShield / 100.0)
-			} else {
-				// RELSHIELD: 0-20 range
-				if (currentShield <= 0) return 2.0
-				if (currentShield >= 20) return 1.0
-				return 2.0 - (currentShield / 20.0)
-			}
-		}
-
-		return 1.0
-	}
-
-	/*
-	 * Computes team composition modifier for shield stats
-	 * Based on bulb type priority and enemy threat
-	 *
-	 * Scoring evolution (for ALLIES receiving shields):
-	 * | Entity Type  | Condition          | Modifier | Rationale                          |
-	 * |--------------|--------------------|---------:|------------------------------------|
-	 * | FIRE_BULB    | always             |     1.5x | benefits most from shields         |
-	 * | HEALER_BULB  | ≤2 healers         |     1.3x | protect the healer                 |
-	 * | HEALER_BULB  | >2 healers         |     0.7x | we have backups                    |
-	 * | METALLIC_BULB| always             |     0.3x | they provide shields, not receive  |
-	 * | other bulbs  | default            |     1.0x | normal priority                    |
-	 * | any ally     | enemy has STR≥100  |    +1.5x | physical damage incoming           |
-	 *
-	 * Scoring evolution (for ENEMIES losing shields):
-	 * | Condition           | Modifier | Rationale                          |
-	 * |---------------------|---------:|------------------------------------|
-	 * | 1 offensive bulb    |     1.3x | our bulb will deal more damage     |
-	 * | 2 offensive bulbs   |     1.6x | more damage potential              |
-	 * | 3+ offensive bulbs  |     2.0x | full offensive team                |
-	 *
-	 * @param entity The entity (ally or enemy)
-	 * @param stat The stat (ABSSHIELD or RELSHIELD)
-	 * @return Multiplier based on team composition
-	 */
-	static real getTeamCompModifier(Entity entity, integer stat) {
-		if (stat != Stats.ABSSHIELD && stat != Stats.RELSHIELD) return 1.0
-
-		integer eType = getEntityType(entity)
-		real modifier = 1.0
-
-		if (entity.isFriend) {
-			// Ally: adjust shield priority by bulb type
-			if (eType == BULB_FIRE) {
-				modifier = 1.5 // fire bulbs benefit most from shields
-			} else if (eType == BULB_HEALER) {
-				modifier = (_countHealer > 2) ? 0.7 : 1.3 // protect healer unless we have many
-			} else if (eType == BULB_METALLIC) {
-				modifier = 0.3 // metallic provides shields, low priority to receive
-			}
-
-			// Boost all ally shields when enemy has physical damage
-			if (_enemyHasStr) {
-				modifier *= 1.5
-			}
-		} else {
-			// Enemy: removing shields is more valuable when we have offensive bulbs
-			if (_countStrBulbs >= 3) {
-				modifier = 2.0
-			} else if (_countStrBulbs >= 2) {
-				modifier = 1.6
-			} else if (_countStrBulbs >= 1) {
-				modifier = 1.3
-			}
-		}
-
-		return modifier
-	}
-
-	/*
-	 * Returns dynamic coefficient with modifiers applied
-	 * Wraps getStatCoef with situational multipliers (lifeRatio, canDie, levelRatio, teamComp)
+	 * Returns dynamic coefficient with all modifiers applied
+	 * Uses ScoringModifiers for individual modifier calculations
 	 * @param entity The entity to get coefficient for
 	 * @param stat The stat type (Stats.HP, Stats.STR, etc.)
 	 * @param consequences Optional consequences to check current HP
@@ -529,19 +131,19 @@ class Scoring {
 
 		// Apply lifeRatio modifier to HP-related stats (both allies and enemies)
 		if (stat == Stats.HP || stat == Stats.HPTIME) {
-			base *= getLifeRatioModifier(entity)
+			base *= ScoringModifiers.getLifeRatioModifier(entity)
 
 			// Apply winning modifier for allies (care less about HP when winning and safe)
 			if (entity.isFriend) {
-				base *= getWinningModifier()
+				base *= ScoringModifiers.getWinningModifier()
 			}
 		}
 
 		// Apply lifeRatio modifier to shields for allies only when enemy has STR
 		// Without physical threat, shields are worth less (0.5x)
 		if (entity.isFriend && (stat == Stats.ABSSHIELD || stat == Stats.RELSHIELD)) {
-			if (_enemyHasStr) {
-				base *= getLifeRatioModifier(entity)
+			if (BattleState.enemyHasStr) {
+				base *= ScoringModifiers.getLifeRatioModifier(entity)
 			} else {
 				base *= 0.5
 			}
@@ -552,7 +154,7 @@ class Scoring {
 			// canDie modifier: massive boost when ally might die
 			if (stat == Stats.HP || stat == Stats.HPTIME || stat == Stats.ABSSHIELD || stat == Stats.RELSHIELD) {
 				if (canDie(entity, consequences)) {
-					base *= CANDIE_MODIFIER
+					base *= ScoringConfig.CANDIE_MODIFIER
 				}
 			}
 
@@ -562,36 +164,36 @@ class Scoring {
 			    stat == Stats.ABSSHIELD || stat == Stats.RELSHIELD ||
 			    stat == Stats.MGC || stat == Stats.MP || stat == Stats.AGI ||
 			    stat == Stats.WSD || stat == Stats.RST) {
-				base *= getLevelRatioModifier(entity)
+				base *= ScoringModifiers.getLevelRatioModifier(entity)
 			}
 
 			// maxHP comparison modifier: low maxHP allies benefit more from HPMAX boosts
 			if (stat == Stats.HPMAX) {
-				base *= getMaxHPComparisonModifier(entity)
+				base *= ScoringModifiers.getMaxHPComparisonModifier(entity)
 			}
 
 			// teamComp modifier: adjust shield value based on team synergy (allies)
 			if (stat == Stats.ABSSHIELD || stat == Stats.RELSHIELD) {
-				base *= getTeamCompModifier(entity, stat)
+				base *= ScoringModifiers.getTeamCompModifier(entity, stat)
 			}
 		}
 
 		// teamComp modifier for enemies: removing shields more valuable with offensive bulbs
 		if (!entity.isFriend) {
 			if (stat == Stats.ABSSHIELD || stat == Stats.RELSHIELD) {
-				base *= getTeamCompModifier(entity, stat)
+				base *= ScoringModifiers.getTeamCompModifier(entity, stat)
 			}
 		}
 
 		// shieldStatus modifier: adjust based on current shield levels
 		if (stat == Stats.ABSSHIELD || stat == Stats.RELSHIELD) {
-			base *= getShieldStatusModifier(entity, stat)
+			base *= ScoringModifiers.getShieldStatusModifier(entity, stat)
 		}
 
 		// STR/MGC modifier for allies: scales with current stat, prefer boosting allies over self
 		if (entity.isFriend && (stat == Stats.STR || stat == Stats.MGC)) {
 			integer currentStat = (stat == Stats.STR) ? entity.str : entity.mgc
-			base *= getStatScalingModifier(currentStat)
+			base *= ScoringModifiers.getStatScalingModifier(currentStat)
 			// Prefer boosting allies over self
 			if (entity != Fight.self) {
 				base *= 1.1
@@ -637,7 +239,7 @@ class Scoring {
 		// WSD/RST modifier for allies: more valuable when relevant chips are ready
 		// Scale: 0.5x at 0 chips, 1.0x at 1, 1.5x at 3+
 		if (entity.isFriend && (stat == Stats.WSD || stat == Stats.RST)) {
-			base *= getChipReadyModifier(entity, stat)
+			base *= ScoringModifiers.getChipReadyModifier(entity, stat)
 			// Prefer boosting allies over self
 			if (entity != Fight.self) {
 				base *= 1.1
@@ -673,7 +275,7 @@ class Scoring {
 
 		// DMGRETURN modifier for allies: valuable when enemy has STR, first application bonus
 		if (entity.isFriend && stat == Stats.DMGRETURN) {
-			if (!_enemyHasStr) {
+			if (!BattleState.enemyHasStr) {
 				base *= 0.5  // No physical threat, dmgReturn less valuable
 			} else {
 				// Smooth scaling from 2x (at 0) to 1x (at 20+)
@@ -692,304 +294,18 @@ class Scoring {
 	}
 
 	/*
-	 * Checks if an ally might die before their next turn
-	 * Uses cached danger and current HP (accounting for consequences)
-	 * @param entity The ally to check
-	 * @param consequences Optional consequences for current HP calculation
-	 * @return true if entity might die before they can act
+	 * Returns effective duration of an effect considering:
+	 * - Infinite duration (-1) converted to remaining turns
+	 * - Turn order (source before/after target)
+	 * - Cap to ScoringConfig.MAX_DURATION for mitigation maps
+	 * @param rawDuration Raw effect duration (-1 = infinite, or 0-8)
+	 * @param source Entity applying the effect
+	 * @param target Entity receiving the effect
+	 * @return Effective duration (0 to ScoringConfig.MAX_DURATION)
 	 */
-	static boolean canDie(Entity entity, Consequences? consequences) {
-		real? danger = _allyDanger[entity]
-		if (danger == null) return false
-		integer currentHP = entity.getCurrentHP(consequences)
-		return currentHP < danger! * CANDIE_THRESHOLD
-	}
-
-	/*
-	 * Computes expected danger for an ally from enemies who play before them
-	 * Uses MapDanger's pre-computed damage maps
-	 * @param ally The ally entity
-	 * @return Expected damage the ally will take before their turn
-	 */
-	static real computeAllyDanger(Entity ally) {
-		real totalDanger = 0.0
-		// Get enemies who play before this ally
-		for (Entity entity in ally.entitiesWhoPlayBefore) {
-			if (entity.isFriend) continue // only enemies
-			// Check each offensive item the enemy has
-			Map<Item, Map<Cell, real>>? enemyMaps = MapDanger._map_entity_item_danger[entity]
-			if (enemyMaps == null) continue
-			integer tpLeft = entity.tp
-			for (Item item in entity.offensiveItems) {
-				Map<Cell, real>? itemMap = enemyMaps![item]
-				if (itemMap == null) continue
-				real? ratioDmg = itemMap![ally.cell]
-				if (ratioDmg == null || ratioDmg <= 0) continue
-				// Estimate damage from this item
-				real itemDmg = Damages.getDamage(entity, ally, item, ratioDmg!, null)
-				if (itemDmg > 0) {
-					integer uses = 0
-					while (item.cost <= tpLeft && uses < item.maxUse) {
-						totalDanger += itemDmg
-						tpLeft -= item.cost
-						uses++
-						if (item.haveCD) break
-					}
-				}
-			}
-		}
-		return totalDanger
-	}
-
-	// === Position Scoring Weights (ML-tunable) ===
-
-	// Danger weights - how much we penalize expected damage
-	static real W_DANGER_BASE = 1.0           // base danger penalty per HP of damage
-	static real W_DANGER_LOW_HP = 1.5         // multiplier when life < 60%
-	static real W_DANGER_CRITICAL = 2.0       // multiplier when danger > life/2
-
-	// Proximity weights - penalty for nearby enemies (excluding primary target)
-	static real W_PROXIMITY_AREA1 = 150.0     // adjacent cell (distance 1)
-	static real W_PROXIMITY_AREA2 = 20.0      // distance 2
-	static real W_PROXIMITY_AREA3 = 10.0      // distance 3
-
-	// Gravity weights - attraction to allies based on their role
-	static real W_GRAVITY_ALLY_SUMMON = 80.0  // we're a summon, stay close to master
-	static real W_GRAVITY_ALLY_SNC600 = 40.0  // high science ally (buffer/healer)
-	static real W_GRAVITY_ALLY_SNC400 = 25.0  // science ally
-	static real W_GRAVITY_ALLY_WIS400 = 25.0  // wisdom ally
-	static real W_GRAVITY_ALLY_RST200 = 10.0  // tanky ally
-	static real W_GRAVITY_ALLY_WIS200 = 8.0   // wisdom ally (lower)
-	static real W_GRAVITY_ALLY_DEFAULT = 1.0  // default ally attraction
-
-	// Bulb-specific gravity
-	static real W_GRAVITY_METALLIC_NEED_ARMOR = 80.0  // metallic bulb when we need shields
-	static real W_GRAVITY_METALLIC_DEFAULT = 6.0      // metallic bulb normally
-	static real W_GRAVITY_HEALER_NEED_HEAL = 40.0     // healer bulb when hurt
-	static real W_GRAVITY_HEALER_DEFAULT = 5.0        // healer bulb normally
-
-	// Tactical weights
-	static real W_LOCK_BONUS = 1000.0         // bonus for locking enemy (computed in refresh)
-	static real W_CAC_IN_RANGE = 1000.0       // bonus if enemy can reach us for melee (we're CAC)
-	static real W_COVID_LEEK = 10000.0      // big bonus for being near uninfected enemy leek
-	static real W_COVID_SUMMON = 1000.0     // bonus for being near uninfected enemy summon
-
-	// Shield weights - value of keeping shields active
-	static real W_SHIELD_ABS = 3.0            // value per point of absolute shield
-	static real W_SHIELD_REL = 6.0            // value per point of relative shield
-
-	// Distance weights for ranged vs melee
-	static integer IDEAL_DIST_RANGED = -1     // calculated at first turn: self.mp + longest item range
-	static integer IDEAL_DIST_CAC = 1         // ideal distance for melee (adjacent)
-	static integer IDEAL_DIST_ALLY = 3        // default ideal distance to allies
-	static integer IDEAL_DIST_CENTER = 4      // ideal distance to map center (cell 306)
-	static integer IDEAL_DIST_METALLIC = 1    // stay close to metallic bulb
-	static integer IDEAL_DIST_HEALER = 4      // healing range
-	
-	static Map<integer, real> defensive_duration_mitigation = [
-		0 : 1.0,
-		1 : 1.0,
-		2 : 1.8,
-		3 : 2.4,
-		4 : 2.8,
-		5 : 3.2,
-		6 : 3.6,
-		7 : 4.0,
-		8 : 4.4,
-	]
-	
-	static Map<integer, real> offensive_duration_mitigation = [
-		0 : 1.0,
-		1 : 1.0,
-		2 : 1.8,
-		3 : 2.4,
-		4 : 2.8,
-		5 : 3.2,
-		6 : 3.6,
-		7 : 4.0,
-		8 : 4.4,
-	]
-	
-	/*
-	 * Initialise les coefs de toutes les entités en vie.
-	 * Appelé à chaque tour.
-	 */
-	static void refresh(){
-		_cache_coef = [:]
-		_cache_duration = [:]
-		_allyDanger = [:]
-
-		// Count ally bulb types for team composition modifiers
-		_countFire = 0
-		_countMetal = 0
-		_countHealer = 0
-		_countStrBulbs = 0
-		for (Entity entity in Fight.getAlliesAlive()) {
-			integer eType = getEntityType(entity)
-			if (eType == BULB_FIRE) {
-				_countFire++
-				_countStrBulbs++
-			} else if (eType == BULB_ICED || eType == BULB_LIGHTNING) {
-				_countStrBulbs++
-			} else if (eType == BULB_METALLIC) {
-				_countMetal++
-			} else if (eType == BULB_HEALER) {
-				_countHealer++
-			}
-		}
-
-		// Check if any enemy has significant strength
-		_enemyHasStr = false
-		for (Entity entity in Fight.getEnemiesAlive()) {
-			if (entity.str >= 100) {
-				_enemyHasStr = true
-				break
-			}
-		}
-
-		// Check if any ally has significant strength (for vuln value on enemies)
-		_allyHasStr = false
-		for (Entity entity in Fight.getAlliesAlive()) {
-			if (entity.str >= 100) {
-				_allyHasStr = true
-				break
-			}
-		}
-
-		// Count ready WSD/RST chips for each ally
-		// Cooldown 0 = 1.0, cooldown 1 = 0.5, cooldown > 1 = 0
-		_wsdReadyChips = [:]
-		_rstReadyChips = [:]
-		for (Entity entity in Fight.getAlliesAlive()) {
-			integer entityId = entity.id
-			real wsdCount = 0.0
-			real rstCount = 0.0
-
-			// Iterate entity.items (already cached)
-			for (Item item in entity.items) {
-				if (item.isWeap) continue
-				integer chipId = item.id
-
-				// Check WSD chips
-				if (inArray(WSD_CHIPS, chipId)) {
-					integer cd = getCooldown(chipId, entityId)
-					if (cd == 0) wsdCount += 1.0
-					else if (cd == 1) wsdCount += 0.5
-				}
-				// Check RST chips
-				if (inArray(RST_CHIPS, chipId)) {
-					integer cd = getCooldown(chipId, entityId)
-					if (cd == 0) rstCount += 1.0
-					else if (cd == 1) rstCount += 0.5
-				}
-			}
-			_wsdReadyChips[entityId] = wsdCount
-			_rstReadyChips[entityId] = rstCount
-		}
-
-		// Compute W_LOCK_BONUS based on vulnerability
-		// Default 1000, reduced to 500 when vulnerable (prioritize survival over locking)
-		boolean notShielded = Fight.self.absShield <= 0 && Fight.self.relShield <= 0
-		boolean notFullLife = Fight.self.life < Fight.self.totalLife
-		if ((notShielded && _enemyHasStr) || notFullLife) {
-			W_LOCK_BONUS = 500.0
-		} else {
-			W_LOCK_BONUS = 1000.0
-		}
-
-		// Compute global HP and count ratios (leeks only, ignore bulbs)
-		// Also compute min/max ally maxHP for HPMAX modifier
-		real sumAllyLife = 0.0
-		real sumEnemyLife = 0.0
-		integer allyCount = 0
-		integer enemyCount = 0
-		_minAllyMaxHP = 999999
-		_maxAllyMaxHP = 0
-		for (Entity entity in Fight.getAlliesLeeksAlive()) {
-			sumAllyLife += entity.life
-			allyCount++
-			if (entity.totalLife < _minAllyMaxHP) _minAllyMaxHP = entity.totalLife
-			if (entity.totalLife > _maxAllyMaxHP) _maxAllyMaxHP = entity.totalLife
-		}
-		for (Entity entity in Fight.getEnemiesLeeksAlive()) {
-			sumEnemyLife += entity.life
-			enemyCount++
-		}
-		_ratioHP = (sumEnemyLife > 0) ? sumAllyLife / sumEnemyLife : 1.0
-		_ratioCount = (enemyCount > 0) ? (allyCount * 1.0) / enemyCount : 1.0
-
-		// Calculate IDEAL_DIST_RANGED once at first turn
-		if (IDEAL_DIST_RANGED == -1) {
-			integer longestRange = 0
-			for (Item item in Fight.self.items) {
-				if (item.maxRange > longestRange) {
-					longestRange = item.maxRange
-				}
-			}
-			IDEAL_DIST_RANGED = Fight.self.mp + longestRange
-		}
-		// Reduce every 5 turns to avoid stalemate
-		if(getTurn()%5 == 0) IDEAL_DIST_RANGED--;
-
-		// Pre-compute effective durations for all raw values (-1 to MAX_DURATION)
-		// Key formula: (rawDuration + 1) * 2 + (sourceAfterTarget ? 1 : 0)
-		integer turnsLeft = MAX_FIGHT_TURNS - getTurn()
-		for(integer raw = -1; raw <= MAX_DURATION; raw++){
-			// For finite durations, cap to turnsLeft (can't benefit longer than fight lasts)
-			integer base = raw == -1 ? turnsLeft : min(raw, turnsLeft)
-			base = min(base, MAX_DURATION)
-			// source plays before target → target gets full duration
-			_cache_duration[(raw + 1) * 2] = max(base, 0)
-			// source plays after target → target gets 1 less turn
-			_cache_duration[(raw + 1) * 2 + 1] = max(base - 1, 0)
-		}
-		for(Entity entity in Fight.getAllAlive()){
-			_cache_coef[entity] = [:]
-			_cache_coef[entity]![Stats.HP] = getStatCoef(entity, Stats.HP)
-			_cache_coef[entity]![Stats.HPTIME] = getStatCoef(entity, Stats.HPTIME)
-			_cache_coef[entity]![Stats.HPMAX] = getStatCoef(entity, Stats.HPMAX)
-			_cache_coef[entity]![Stats.DEBUFF] = getStatCoef(entity, Stats.DEBUFF)
-			_cache_coef[entity]![Stats.ANTIDOTE] = getStatCoef(entity, Stats.ANTIDOTE)
-			_cache_coef[entity]![Stats.ABSSHIELD] = getStatCoef(entity, Stats.ABSSHIELD)
-			_cache_coef[entity]![Stats.RELSHIELD] = getStatCoef(entity, Stats.RELSHIELD)
-			_cache_coef[entity]![Stats.DMGRETURN] = getStatCoef(entity, Stats.DMGRETURN)
-			_cache_coef[entity]![Stats.STR] = getStatCoef(entity, Stats.STR)
-			_cache_coef[entity]![Stats.MGC] = getStatCoef(entity, Stats.MGC)
-			_cache_coef[entity]![Stats.RST] = getStatCoef(entity, Stats.RST)
-			_cache_coef[entity]![Stats.WSD] = getStatCoef(entity, Stats.WSD)
-			_cache_coef[entity]![Stats.AGI] = getStatCoef(entity, Stats.AGI)
-			_cache_coef[entity]![Stats.TP] = getStatCoef(entity, Stats.TP)
-			_cache_coef[entity]![Stats.MP] = getStatCoef(entity, Stats.MP)
-			_cache_coef[entity]![Stats.PWR] = getStatCoef(entity, Stats.PWR)
-			_cache_coef[entity]![Stats.KILL] = getStatCoef(entity, Stats.KILL)
-
-			// Compute danger for allies (not self - we handle our own danger elsewhere)
-			if (entity.isFriend && entity != Fight.self) {
-				_allyDanger[entity] = computeAllyDanger(entity)
-			}
-		}
-	}
-	
-	/*
-	 * retourne le coef d'une entity pour la key donnée
-	 */
-	static real getCoef(Entity entity, integer key){
-		return _cache_coef[entity]![key]!
-	}
-
-	/*
-	 * Retourne la durée effective d'un effet en tenant compte de:
-	 * - La durée infinie (-1) convertie en tours restants
-	 * - L'ordre de jeu (source avant/après target)
-	 * - Le cap à MAX_DURATION pour les maps de mitigation
-	 * @param rawDuration durée brute de l'effet (-1 = infini, ou 0-8)
-	 * @param source entité qui applique l'effet
-	 * @param target entité qui reçoit l'effet
-	 * @return durée effective (0 à MAX_DURATION)
-	 */
-	static integer getEffectiveDuration(integer rawDuration, Entity source, Entity target){
-		// Cap rawDuration to valid cache range (handles raw > MAX_DURATION)
-		integer cappedRaw = rawDuration == -1 ? -1 : min(rawDuration, MAX_DURATION)
+	static integer getEffectiveDuration(integer rawDuration, Entity source, Entity target) {
+		// Cap rawDuration to valid cache range (handles raw > ScoringConfig.MAX_DURATION)
+		integer cappedRaw = rawDuration == -1 ? -1 : min(rawDuration, ScoringConfig.MAX_DURATION)
 		integer key = (cappedRaw + 1) * 2 + (source.turnOrder > target.turnOrder ? 1 : 0)
 		return _cache_duration[key]!
 	}

--- a/AI/ScoringConfig
+++ b/AI/ScoringConfig
@@ -1,0 +1,97 @@
+/*
+ * ScoringConfig - Configuration and constants for the scoring system
+ *
+ * Contains all ML-tunable weights, thresholds, and duration mitigation tables.
+ * Centralizes configuration for easy tuning and experimentation.
+ *
+ * Used by: Scoring, ScoringModifiers, MapPosition, Position
+ */
+class ScoringConfig {
+
+	// === Combat Values ===
+	static integer KILL_VALUE = 2000
+	static integer DEATH_VALUE = -2000
+	static integer MAX_FIGHT_TURNS = 66
+	static integer MAX_DURATION = 8 // max index in duration_mitigation maps
+
+	// === CanDie Thresholds ===
+	static real CANDIE_MODIFIER = 10.0   // massive boost when ally might die
+	static real CANDIE_THRESHOLD = 0.8   // ally.hp < danger * threshold → canDie
+	static real IGNORE_DANGER_RATIO = 0.1 // ignore damage < 10% of current life
+
+	// === Chip Maps for WSD/RST Modifiers (O(1) lookup) ===
+	static Map<integer, boolean> WSD_CHIPS = [CHIP_ELEVATION: true, CHIP_CURE: true, CHIP_VACCINE: true, CHIP_ARMORING: true, CHIP_REMISSION: true]
+	static Map<integer, boolean> RST_CHIPS = [CHIP_HELMET: true, CHIP_SHIELD: true, CHIP_ARMOR: true, CHIP_WALL: true, CHIP_FORTRESS: true]
+
+	// === Position Scoring Weights (ML-tunable) ===
+
+	// Danger weights - how much we penalize expected damage
+	static real W_DANGER_BASE = 1.0           // base danger penalty per HP of damage
+	static real W_DANGER_LOW_HP = 1.5         // multiplier when life < 60%
+	static real W_DANGER_CRITICAL = 2.0       // multiplier when danger > life/2
+
+	// Proximity weights - penalty for nearby enemies (excluding primary target)
+	static real W_PROXIMITY_AREA1 = 150.0     // adjacent cell (distance 1)
+	static real W_PROXIMITY_AREA2 = 20.0      // distance 2
+	static real W_PROXIMITY_AREA3 = 10.0      // distance 3
+
+	// Gravity weights - attraction to allies based on their role
+	static real W_GRAVITY_ALLY_SUMMON = 80.0  // we're a summon, stay close to master
+	static real W_GRAVITY_ALLY_SNC600 = 40.0  // high science ally (buffer/healer)
+	static real W_GRAVITY_ALLY_SNC400 = 25.0  // science ally
+	static real W_GRAVITY_ALLY_WIS400 = 25.0  // wisdom ally
+	static real W_GRAVITY_ALLY_RST200 = 10.0  // tanky ally
+	static real W_GRAVITY_ALLY_WIS200 = 8.0   // wisdom ally (lower)
+	static real W_GRAVITY_ALLY_DEFAULT = 1.0  // default ally attraction
+
+	// Bulb-specific gravity
+	static real W_GRAVITY_METALLIC_NEED_ARMOR = 80.0  // metallic bulb when we need shields
+	static real W_GRAVITY_METALLIC_DEFAULT = 6.0      // metallic bulb normally
+	static real W_GRAVITY_HEALER_NEED_HEAL = 40.0     // healer bulb when hurt
+	static real W_GRAVITY_HEALER_DEFAULT = 5.0        // healer bulb normally
+
+	// Tactical weights
+	// Note: W_LOCK_BONUS is in Scoring (dynamically computed in refresh)
+	static real W_CAC_IN_RANGE = 1000.0       // bonus if enemy can reach us for melee (we're CAC)
+	static real W_COVID_LEEK = 10000.0        // big bonus for being near uninfected enemy leek
+	static real W_COVID_SUMMON = 1000.0       // bonus for being near uninfected enemy summon
+
+	// Shield weights - value of keeping shields active
+	static real W_SHIELD_ABS = 3.0            // value per point of absolute shield
+	static real W_SHIELD_REL = 6.0            // value per point of relative shield
+
+	// === Distance Weights ===
+	// Note: IDEAL_DIST_RANGED is in Scoring (dynamically computed in refresh)
+	static integer IDEAL_DIST_CAC = 1         // ideal distance for melee (adjacent)
+	static integer IDEAL_DIST_ALLY = 3        // default ideal distance to allies
+	static integer IDEAL_DIST_CENTER = 4      // ideal distance to map center (cell 306)
+	static integer IDEAL_DIST_METALLIC = 1    // stay close to metallic bulb
+	static integer IDEAL_DIST_HEALER = 4      // healing range
+
+	// === Duration Mitigation Tables ===
+	// Maps effect duration to value multiplier (diminishing returns for long durations)
+
+	static Map<integer, real> defensive_duration_mitigation = [
+		0 : 1.0,
+		1 : 1.0,
+		2 : 1.8,
+		3 : 2.4,
+		4 : 2.8,
+		5 : 3.2,
+		6 : 3.6,
+		7 : 4.0,
+		8 : 4.4
+	]
+
+	static Map<integer, real> offensive_duration_mitigation = [
+		0 : 1.0,
+		1 : 1.0,
+		2 : 1.8,
+		3 : 2.4,
+		4 : 2.8,
+		5 : 3.2,
+		6 : 3.6,
+		7 : 4.0,
+		8 : 4.4
+	]
+}

--- a/AI/ScoringModifiers
+++ b/AI/ScoringModifiers
@@ -1,0 +1,317 @@
+/*
+ * ScoringModifiers - Pure modifier functions for action scoring
+ *
+ * Contains all modifier functions that adjust base coefficients based on
+ * situational context (life ratio, level, team composition, shields, etc.)
+ *
+ * These are pure functions with no dependencies on Scoring class.
+ * Used by Scoring.getDynamicCoef() to transform base coefficients.
+ *
+ * Used by: Scoring
+ */
+class ScoringModifiers {
+
+	// Precomputed: 0.5 / log(301) ≈ 0.0876
+	static real LEVEL_RATIO_SCALE = 0.0876
+
+	/*
+	 * Computes lifeRatio modifier: more valuable to heal/damage low HP targets
+	 *
+	 * ALLY formula: min(2/lifeRatio - 1, 10.0) - aggressive curve for healing urgency
+	 * | lifeRatio | modifier | meaning                          |
+	 * |-----------|----------|----------------------------------|
+	 * | 1.00      | 1.0      | full HP → no bonus               |
+	 * | 0.80      | 1.5      | slightly hurt → small boost      |
+	 * | 0.67      | 2.0      | 2/3 HP → double value            |
+	 * | 0.50      | 3.0      | half HP → triple value           |
+	 * | 0.40      | 4.0      | hurt → 4x value                  |
+	 * | 0.25      | 7.0      | critical → 7x value              |
+	 * | 0.20      | 9.0      | near death → 9x value            |
+	 * | ≤0.18     | 10.0     | dying → capped at 10x            |
+	 *
+	 * ENEMY formula: 10 - 8 * lifeRatio - linear from 2 (full) to 10 (dead)
+	 * | lifeRatio | modifier | meaning                          |
+	 * |-----------|----------|----------------------------------|
+	 * | 1.00      | 2.0      | full HP → base priority          |
+	 * | 0.75      | 4.0      | wounded → increasing priority    |
+	 * | 0.50      | 6.0      | half HP → 6x value               |
+	 * | 0.25      | 8.0      | low HP → 8x value                |
+	 * | 0.10      | 9.2      | critical → near max              |
+	 * | 0.00      | 10.0     | dead → capped at 10x             |
+	 */
+	static real getLifeRatioModifier(Entity entity) {
+		real lifeRatio = entity.life / entity.totalLife
+		if (lifeRatio <= 0.0) return 10.0 // safety: dead or invalid
+
+		if (entity.isFriend) {
+			// Ally: aggressive curve - prioritize healing low HP allies
+			return min(2.0 / lifeRatio - 1.0, 10.0)
+		} else {
+			// Enemy: linear curve from 2 (full HP) to 10 (dead)
+			return 10.0 - 8.0 * lifeRatio
+		}
+	}
+
+	/*
+	 * Computes levelRatio modifier: more valuable to buff high-level allies
+	 * Formula: 1.0 + 0.5 * log(targetLevel / selfLevel) / log(301)
+	 *
+	 * Scoring evolution (logarithmic, symmetric):
+	 * | level ratio | modifier | meaning                          |
+	 * |-------------|----------|----------------------------------|
+	 * | 1/301       | 0.50     | buffing lvl 1 as lvl 301 → half  |
+	 * | 1/10        | 0.80     | buffing much lower level         |
+	 * | 1/2         | 0.94     | buffing slightly lower level     |
+	 * | 1           | 1.00     | same level → no change           |
+	 * | 2           | 1.06     | buffing slightly higher level    |
+	 * | 10          | 1.20     | buffing much higher level        |
+	 * | 301         | 1.50     | buffing lvl 301 as lvl 1 → 1.5x  |
+	 */
+	static real getLevelRatioModifier(Entity entity) {
+		integer selfLevel = Fight.self.level
+		if (selfLevel <= 0) return 1.0 // safety
+		real ratio = entity.level / selfLevel
+		if (ratio <= 0.0) return 0.5 // safety: clamp to minimum
+		return max(0.5, min(1.5, 1.0 + LEVEL_RATIO_SCALE * log(ratio)))
+	}
+
+	/*
+	 * Computes STR/MGC scaling modifier based on current stat level
+	 * Peak value at 1000, diminishing returns above
+	 *
+	 * Scoring evolution:
+	 * | Current stat | modifier | meaning                        |
+	 * |--------------|----------|--------------------------------|
+	 * | 0            | 0.5      | no stat, low value to boost    |
+	 * | 500          | 1.0      | mid stat                       |
+	 * | 1000         | 1.5      | peak value (scales best)       |
+	 * | 1500         | 1.0      | diminishing returns            |
+	 * | 2000+        | 0.5      | very high, minimal benefit     |
+	 */
+	static real getStatScalingModifier(integer currentStat) {
+		if (currentStat <= 0) return 0.5
+		if (currentStat <= 1000) {
+			// Linear 0.5 → 1.5 over 0 → 1000
+			return 0.5 + (currentStat / 1000.0)
+		}
+		if (currentStat <= 2000) {
+			// Linear 1.5 → 0.5 over 1000 → 2000
+			return 1.5 - ((currentStat - 1000) / 1000.0)
+		}
+		return 0.5
+	}
+
+	/*
+	 * Computes maxHP comparison modifier for HPMAX stat
+	 * Low maxHP allies benefit more from HPMAX boosts
+	 *
+	 * Scoring evolution:
+	 * | Entity maxHP position | modifier | meaning                    |
+	 * |-----------------------|----------|----------------------------|
+	 * | lowest among allies   | 1.5      | needs HP boost most        |
+	 * | average               | 1.0      | neutral                    |
+	 * | highest among allies  | 0.5      | doesn't need it as much    |
+	 *
+	 * @param entity The ally entity
+	 * @return Multiplier for HPMAX coefficient (0.5 to 1.5)
+	 */
+	static real getMaxHPComparisonModifier(Entity entity) {
+		if (BattleState.maxAllyMaxHP <= BattleState.minAllyMaxHP) return 1.0  // all same or invalid
+
+		// Where does this entity fall in the range? (0 = lowest, 1 = highest)
+		real position = (entity.totalLife - BattleState.minAllyMaxHP) * 1.0 / (BattleState.maxAllyMaxHP - BattleState.minAllyMaxHP)
+
+		// Invert: low maxHP → high modifier (1.5), high maxHP → low modifier (0.5)
+		return 1.5 - position
+	}
+
+	/*
+	 * Gets the chip readiness modifier for WSD or RST
+	 * Chips at cooldown 0 count as 1.0, cooldown 1 counts as 0.5
+	 *
+	 * Scoring evolution:
+	 * | Ready count | modifier | meaning                        |
+	 * |-------------|----------|--------------------------------|
+	 * | 0           | 0.5      | no chips ready, low value      |
+	 * | 0.5         | 0.75     | one chip at cooldown 1         |
+	 * | 1           | 1.0      | one chip ready                 |
+	 * | 2           | 1.25     | two chips ready                |
+	 * | 3+          | 1.5      | many chips ready               |
+	 *
+	 * @param entity The ally entity
+	 * @param stat Stats.WSD or Stats.RST
+	 * @return Multiplier for stat coefficient
+	 */
+	static real getChipReadyModifier(Entity entity, integer stat) {
+		real readyCount = 0.0
+		if (stat == Stats.WSD) {
+			readyCount = BattleState.wsdReadyChips[entity.id]  // null coerces to 0
+		} else if (stat == Stats.RST) {
+			readyCount = BattleState.rstReadyChips[entity.id]  // null coerces to 0
+		}
+
+		if (readyCount <= 0) return 0.5
+		if (readyCount <= 1) {
+			// Linear 0.5 → 1.0 over 0 → 1
+			return 0.5 + 0.5 * readyCount
+		}
+		if (readyCount <= 3) {
+			// Linear 1.0 → 1.5 over 1 → 3
+			return 1.0 + 0.25 * (readyCount - 1)
+		}
+		return 1.5
+	}
+
+	/*
+	 * Computes winning modifier based on global HP and count ratios
+	 * Adjusts how much we care about ally HP/HPTIME based on match state
+	 *
+	 * Note: Individual danger (low HP, no shields, canDie) is handled by
+	 * other modifiers - this is ONLY about global winning/losing state.
+	 *
+	 * Formula: modifier = 1.5 - 0.5 * combined, clamped to [0.5, 1.5]
+	 * where combined = (ratioHP + ratioCount) / 2
+	 *
+	 * Scoring evolution:
+	 * | ratioHP | ratioCount | combined | modifier | meaning              |
+	 * |---------|------------|----------|----------|----------------------|
+	 * | 2.0     | 2.0        | 2.0      | 0.5      | winning → relax      |
+	 * | 1.5     | 1.5        | 1.5      | 0.75     | ahead                |
+	 * | 1.0     | 1.0        | 1.0      | 1.0      | even → neutral       |
+	 * | 0.5     | 0.5        | 0.5      | 1.25     | behind               |
+	 * | 0.33    | 0.33       | 0.33     | 1.5      | losing → prioritize  |
+	 *
+	 * @return Multiplier for ally HP/HPTIME coefficients
+	 */
+	static real getWinningModifier() {
+		real combined = (BattleState.ratioHP + BattleState.ratioCount) / 2.0
+		real modifier = 1.5 - 0.5 * combined
+		return max(0.5, min(1.5, modifier))
+	}
+
+	/*
+	 * Computes shield status modifier based on current shield levels
+	 * More valuable to shield unshielded allies / remove shields from unshielded enemies
+	 *
+	 * Scoring evolution (for ALLIES):
+	 * | Entity      | Current Shield | enemyHasStr | Modifier | Rationale                  |
+	 * |-------------|----------------|-------------|----------|----------------------------|
+	 * | LEEK        | 0              | yes         |     3.0x | urgent need for shields    |
+	 * | LEEK        | ≤80            | yes         |     2.0x | low shields, STR incoming  |
+	 * | LEEK        | any            | no          |     1.0x | no physical threat         |
+	 * | FIRE_BULB   | 0              | any         |     2.0x | fire bulb needs protection |
+	 * | other       | any            | any         |     1.0x | default                    |
+	 *
+	 * Scoring evolution (for ENEMIES - inverted logic):
+	 * | Current Shield | Modifier | Rationale                              |
+	 * |----------------|----------|----------------------------------------|
+	 * | 0              |     0.5x | already unshielded, less urgent        |
+	 * | ≤100           |     1.5x | low shields, worth removing            |
+	 * | >100           |     1.0x | normal priority                        |
+	 *
+	 * @param entity The entity
+	 * @param stat ABSSHIELD or RELSHIELD
+	 * @return Multiplier based on current shield status
+	 */
+	static real getShieldStatusModifier(Entity entity, integer stat) {
+		if (stat != Stats.ABSSHIELD && stat != Stats.RELSHIELD) return 1.0
+
+		// Get current shield value
+		integer currentShield = (stat == Stats.ABSSHIELD) ? entity.absShield : entity.relShield
+
+		if (entity.isFriend) {
+			// Ally: boost when unshielded and enemy has STR
+			integer eType = EntityTypes.getEntityType(entity)
+
+			// Fire bulb with no shields: extra boost
+			if (eType == EntityTypes.BULB_FIRE && currentShield <= 0) {
+				return 2.0
+			}
+
+			// Leek with low/no shields when enemy has STR
+			if (eType == ENTITY_LEEK && BattleState.enemyHasStr) {
+				if (currentShield <= 0) return 3.0
+				if (currentShield <= 80) return 2.0
+			}
+		} else {
+			// Enemy: vuln value - based on whether WE have STR to exploit it
+			if (!BattleState.allyHasStr) {
+				return 0.5  // No STR, vuln is less valuable
+			}
+
+			// Smooth scaling from 2x (at 0) to 1x (at threshold)
+			// ABSSHIELD: 0-100 range, RELSHIELD: 0-20 range
+			if (stat == Stats.ABSSHIELD) {
+				if (currentShield <= 0) return 2.0
+				if (currentShield >= 100) return 1.0
+				return 2.0 - (currentShield / 100.0)
+			} else {
+				// RELSHIELD: 0-20 range
+				if (currentShield <= 0) return 2.0
+				if (currentShield >= 20) return 1.0
+				return 2.0 - (currentShield / 20.0)
+			}
+		}
+
+		return 1.0
+	}
+
+	/*
+	 * Computes team composition modifier for shield stats
+	 * Based on bulb type priority and enemy threat
+	 *
+	 * Scoring evolution (for ALLIES receiving shields):
+	 * | Entity Type  | Condition          | Modifier | Rationale                          |
+	 * |--------------|--------------------|---------:|------------------------------------|
+	 * | FIRE_BULB    | always             |     1.5x | benefits most from shields         |
+	 * | HEALER_BULB  | ≤2 healers         |     1.3x | protect the healer                 |
+	 * | HEALER_BULB  | >2 healers         |     0.7x | we have backups                    |
+	 * | METALLIC_BULB| always             |     0.3x | they provide shields, not receive  |
+	 * | other bulbs  | default            |     1.0x | normal priority                    |
+	 * | any ally     | enemy has STR≥100  |    +1.5x | physical damage incoming           |
+	 *
+	 * Scoring evolution (for ENEMIES losing shields):
+	 * | Condition           | Modifier | Rationale                          |
+	 * |---------------------|---------:|------------------------------------|
+	 * | 1 offensive bulb    |     1.3x | our bulb will deal more damage     |
+	 * | 2 offensive bulbs   |     1.6x | more damage potential              |
+	 * | 3+ offensive bulbs  |     2.0x | full offensive team                |
+	 *
+	 * @param entity The entity (ally or enemy)
+	 * @param stat The stat (ABSSHIELD or RELSHIELD)
+	 * @return Multiplier based on team composition
+	 */
+	static real getTeamCompModifier(Entity entity, integer stat) {
+		if (stat != Stats.ABSSHIELD && stat != Stats.RELSHIELD) return 1.0
+
+		integer eType = EntityTypes.getEntityType(entity)
+		real modifier = 1.0
+
+		if (entity.isFriend) {
+			// Ally: adjust shield priority by bulb type
+			if (eType == EntityTypes.BULB_FIRE) {
+				modifier = 1.5 // fire bulbs benefit most from shields
+			} else if (eType == EntityTypes.BULB_HEALER) {
+				modifier = (BattleState.countHealer > 2) ? 0.7 : 1.3 // protect healer unless we have many
+			} else if (eType == EntityTypes.BULB_METALLIC) {
+				modifier = 0.3 // metallic provides shields, low priority to receive
+			}
+
+			// Boost all ally shields when enemy has physical damage
+			if (BattleState.enemyHasStr) {
+				modifier *= 1.5
+			}
+		} else {
+			// Enemy: removing shields is more valuable when we have offensive bulbs
+			if (BattleState.countStrBulbs >= 3) {
+				modifier = 2.0
+			} else if (BattleState.countStrBulbs >= 2) {
+				modifier = 1.6
+			} else if (BattleState.countStrBulbs >= 1) {
+				modifier = 1.3
+			}
+		}
+
+		return modifier
+	}
+}

--- a/Controlers/Maps/MapPosition
+++ b/Controlers/Maps/MapPosition
@@ -9,7 +9,7 @@ class MapPosition {
 	static real _total_ally_coef = 0.0
 
 	// === Threat detection ===
-	static boolean _enemies_have_str = false
+	// Note: enemyHasStr is now in BattleState.enemyHasStr
 	static boolean _enemies_have_snc = false
 	static boolean _need_shields = false
 	static boolean _is_cac = false
@@ -55,17 +55,16 @@ class MapPosition {
 
 	/*
 	 * Detect enemy threat levels
+	 * Note: enemyHasStr is computed in BattleState.refresh()
 	 */
 	static void _refreshThreatDetection() {
-		_enemies_have_str = false
 		_enemies_have_snc = false
 
 		for (Entity e in Fight.getEnemiesAlive()) {
-			if (e.str > 100) _enemies_have_str = true
 			if (e.snc > 200) _enemies_have_snc = true
 		}
 
-		_need_shields = (_enemies_have_str || _enemies_have_snc) &&
+		_need_shields = (BattleState.enemyHasStr || _enemies_have_snc) &&
 						(Fight.self.absShield == 0 || Fight.self.relShield == 0)
 
 		_is_cac = false
@@ -87,14 +86,14 @@ class MapPosition {
 
 		for (Entity ally in Fight.getAlliesLeeksAlive()) {
 			if (ally == Fight.self) continue;
-			if (isSummon) coef = Scoring.W_GRAVITY_ALLY_SUMMON
-			else if (ally.snc >= 600) coef = Scoring.W_GRAVITY_ALLY_SNC600
-			else if (ally.snc >= 400) coef = Scoring.W_GRAVITY_ALLY_SNC400
-			else if (ally.wsd >= 400) coef = Scoring.W_GRAVITY_ALLY_WIS400
-			else if (ally.rst >= 200) coef = Scoring.W_GRAVITY_ALLY_RST200
-			else if (ally.wsd >= 200) coef = Scoring.W_GRAVITY_ALLY_WIS200
-			else coef = Scoring.W_GRAVITY_ALLY_DEFAULT
-			_gravity_distance[ally.cell] = Scoring.IDEAL_DIST_ALLY
+			if (isSummon) coef = ScoringConfig.W_GRAVITY_ALLY_SUMMON
+			else if (ally.snc >= 600) coef = ScoringConfig.W_GRAVITY_ALLY_SNC600
+			else if (ally.snc >= 400) coef = ScoringConfig.W_GRAVITY_ALLY_SNC400
+			else if (ally.wsd >= 400) coef = ScoringConfig.W_GRAVITY_ALLY_WIS400
+			else if (ally.rst >= 200) coef = ScoringConfig.W_GRAVITY_ALLY_RST200
+			else if (ally.wsd >= 200) coef = ScoringConfig.W_GRAVITY_ALLY_WIS200
+			else coef = ScoringConfig.W_GRAVITY_ALLY_DEFAULT
+			_gravity_distance[ally.cell] = ScoringConfig.IDEAL_DIST_ALLY
 			_gravity_coef[ally.cell] = coef
 			_total_ally_coef += coef
 		}
@@ -102,10 +101,10 @@ class MapPosition {
 		if (!isSummon) {
 			real lifeRatio = Fight.self.life / Fight.self.totalLife
 			for (Entity bulb in Fight.getAlliesBulbsAlive()) {
-				_gravity_distance[bulb.cell] = Scoring.IDEAL_DIST_ALLY
-				if (_need_shields) coef = Scoring.W_GRAVITY_METALLIC_NEED_ARMOR
-				else if (lifeRatio < 0.9) coef = Scoring.W_GRAVITY_HEALER_NEED_HEAL
-				else coef = Scoring.W_GRAVITY_ALLY_DEFAULT
+				_gravity_distance[bulb.cell] = ScoringConfig.IDEAL_DIST_ALLY
+				if (_need_shields) coef = ScoringConfig.W_GRAVITY_METALLIC_NEED_ARMOR
+				else if (lifeRatio < 0.9) coef = ScoringConfig.W_GRAVITY_HEALER_NEED_HEAL
+				else coef = ScoringConfig.W_GRAVITY_ALLY_DEFAULT
 				_gravity_coef[bulb.cell] = coef
 				_total_ally_coef += coef
 			}
@@ -125,7 +124,7 @@ class MapPosition {
 		}
 		if (enemyCoef < 1) enemyCoef = 1
 
-		integer distToEnemy = _is_cac ? Scoring.IDEAL_DIST_CAC : Scoring.IDEAL_DIST_RANGED
+		integer distToEnemy = _is_cac ? ScoringConfig.IDEAL_DIST_CAC : Scoring.IDEAL_DIST_RANGED
 		for (Entity enemy in enemies) {
 			_gravity_distance[enemy.cell] = distToEnemy
 			_gravity_coef[enemy.cell] = enemyCoef
@@ -133,14 +132,14 @@ class MapPosition {
 
 		if (distToEnemy < 20 && !_need_shields) {
 			for (Entity eBulb in Fight.getEnemiesBulbsAlive()) {
-				_gravity_distance[eBulb.cell] = Scoring.IDEAL_DIST_CAC
+				_gravity_distance[eBulb.cell] = ScoringConfig.IDEAL_DIST_CAC
 				_gravity_coef[eBulb.cell] = enemyCoef * 0.5
 			}
 		}
 
 		Cell? centerCell = Board.getCell(306)
 		if (centerCell != null) {
-			_gravity_distance[centerCell!] = Scoring.IDEAL_DIST_CENTER
+			_gravity_distance[centerCell!] = ScoringConfig.IDEAL_DIST_CENTER
 			_gravity_coef[centerCell!] = enemyCoef
 		}
 	}
@@ -233,9 +232,9 @@ class MapPosition {
 		pos.addGravityScore(MapPosition._computeGravityScore(cell))
 		pos.addTacticalScore(MapPosition._computeTacticalScore(cell, consequences))
 
-		if (_enemies_have_str || _enemies_have_snc) {
-			real shieldValue = Fight.self.getCurrentAbs(consequences) * Scoring.W_SHIELD_ABS +
-							   Fight.self.getCurrentRel(consequences) * Scoring.W_SHIELD_REL
+		if (BattleState.enemyHasStr || _enemies_have_snc) {
+			real shieldValue = Fight.self.getCurrentAbs(consequences) * ScoringConfig.W_SHIELD_ABS +
+							   Fight.self.getCurrentRel(consequences) * ScoringConfig.W_SHIELD_REL
 			pos.addShieldScore(shieldValue)
 		}
 
@@ -264,7 +263,7 @@ class MapPosition {
 			if (c == cell) continue
 			Entity? enemy = Board.entityCells[c]
 			if (enemy != null && !enemy!.isFriend && c != primaryCell) {
-				penalty -= Scoring.W_PROXIMITY_AREA1
+				penalty -= ScoringConfig.W_PROXIMITY_AREA1
 			}
 		}
 
@@ -272,7 +271,7 @@ class MapPosition {
 			if (inArray(cell.getAreaCells(AREA_CIRCLE_1), c)) continue
 			Entity? enemy = Board.entityCells[c]
 			if (enemy != null && !enemy!.isFriend && c != primaryCell) {
-				penalty -= Scoring.W_PROXIMITY_AREA2
+				penalty -= ScoringConfig.W_PROXIMITY_AREA2
 			}
 		}
 
@@ -280,7 +279,7 @@ class MapPosition {
 			if (inArray(cell.getAreaCells(AREA_CIRCLE_2), c)) continue
 			Entity? enemy = Board.entityCells[c]
 			if (enemy != null && !enemy!.isFriend && c != primaryCell) {
-				penalty -= Scoring.W_PROXIMITY_AREA3
+				penalty -= ScoringConfig.W_PROXIMITY_AREA3
 			}
 		}
 
@@ -313,7 +312,7 @@ class MapPosition {
 			if (_is_cac && _nearest_enemy != null && targetCell == _nearest_enemy!.cell) {
 				integer enemyMP = _nearest_enemy!.mp - _nearest_enemy!.altMP
 				if (actualDist <= enemyMP + Fight.self.mp) {
-					score += Scoring.W_CAC_IN_RANGE
+					score += ScoringConfig.W_CAC_IN_RANGE
 				}
 			}
 
@@ -354,9 +353,9 @@ class MapPosition {
 					boolean hasCovid = _entity_has_covid[enemy!] == true
 					if (!hasCovid) {
 						if (enemy!.isBulb) {
-							bonus += Scoring.W_COVID_SUMMON
+							bonus += ScoringConfig.W_COVID_SUMMON
 						} else {
-							bonus += Scoring.W_COVID_LEEK
+							bonus += ScoringConfig.W_COVID_LEEK
 						}
 					}
 				}

--- a/Model/Combos/Consequences
+++ b/Model/Combos/Consequences
@@ -119,14 +119,14 @@ class Consequences {
 		real coef = Scoring.getDynamicCoef(entity, key, this)
 		real scoreDelta = value * coef
 		if(!isOverTime) this.score += scoreDelta
-		else this.score += scoreDelta * Scoring.offensive_duration_mitigation[(effect as EffectOverTime).duration]!
+		else this.score += scoreDelta * ScoringConfig.offensive_duration_mitigation[(effect as EffectOverTime).duration]!
 	}
 	
 	void addKill(Entity entity){
 		this.isAlteringDanger=true
 		this.hashcode = 31 * this.hashcode + entity.id
 		this._killed[entity]=entity
-		this.score+= Scoring.KILL_VALUE * Scoring.getDynamicCoef(entity, Stats.KILL, this)
+		this.score+= ScoringConfig.KILL_VALUE * Scoring.getDynamicCoef(entity, Stats.KILL, this)
 		// Inline passive for kill
 		Map<integer, real> passives = Fight.self.passives
 		if(passives[EFFECT_KILL_TO_TP]) {

--- a/Model/Combos/Danger
+++ b/Model/Combos/Danger
@@ -13,7 +13,7 @@ class Danger{
 		this.combo = str
 		this.score = -dmg // je souhaite le min de dmg, à raison de -1score par dmg, == dmg dealt pour le moment
 		if(dmg >= Fight.self.getCurrentHP(consequences)) // TODO gérer les conséquences de heal dans le danger ?
-			this.score += Scoring.DEATH_VALUE
+			this.score += ScoringConfig.DEATH_VALUE
 	}
 	
 	/*

--- a/Model/Combos/Position
+++ b/Model/Combos/Position
@@ -72,7 +72,7 @@ class Position extends Danger {
 
 		// Ignore small damage (scratches < 10% of current life)
 		// Cancel the score penalty but keep dmg visible for debugging
-		if (this.dmg < currentLife * Scoring.IGNORE_DANGER_RATIO) {
+		if (this.dmg < currentLife * ScoringConfig.IGNORE_DANGER_RATIO) {
 			this.score += this.dmg  // cancel the -dmg penalty
 			return
 		}
@@ -82,12 +82,12 @@ class Position extends Danger {
 
 		// Low HP scaling (below 60%)
 		if (lifePercent < 0.6) {
-			scaledDangerScore *= Scoring.W_DANGER_LOW_HP
+			scaledDangerScore *= ScoringConfig.W_DANGER_LOW_HP
 		}
 
 		// Critical danger scaling (danger > half of remaining life)
 		if (this.dmg > currentLife / 2) {
-			scaledDangerScore *= Scoring.W_DANGER_CRITICAL
+			scaledDangerScore *= ScoringConfig.W_DANGER_CRITICAL
 		}
 
 		// Apply the difference (since base score already has -dmg)

--- a/Model/GameObject/Entity
+++ b/Model/GameObject/Entity
@@ -38,6 +38,7 @@ class Entity {
 	boolean isStatic = false     // ADD_STATE value 11 - no STATE_STATIC constant in leekwars api
 	boolean isInvincible = false // ADD_STATE value STATE_INVINCIBLE (3)
 	integer entityType  // ENTITY_LEEK, ENTITY_BULB, ENTITY_TURRET, ENTITY_CHEST, ENTITY_MOB
+	integer extendedType  // Cached: for bulbs, specific type (101-108); otherwise same as entityType
 	// gestions des effets
 	Array<EntityEffect> effects = []
 	Map<Item, Array<EffectOverTime>> items_effectOverTime = [:]
@@ -94,6 +95,21 @@ class Entity {
 		this.isFriend = isAlly(id)
 		this.isBulb = isSummon(id)!
 		this.entityType = getType(id)!
+		// Cache extended type (bulb-specific type detection done once here)
+		if (this.isBulb) {
+			string n = this.name
+			if (n == "metallic_bulb") this.extendedType = 106
+			else if (n == "healer_bulb") this.extendedType = 101
+			else if (n == "lightning_bulb") this.extendedType = 105
+			else if (n == "wizard_bulb") this.extendedType = 102
+			else if (n == "fire_bulb") this.extendedType = 103
+			else if (n == "iced_bulb") this.extendedType = 104
+			else if (n == "rocky_bulb") this.extendedType = 107
+			else if (n == "puny_bulb") this.extendedType = 108
+			else this.extendedType = ENTITY_BULB
+		} else {
+			this.extendedType = this.entityType
+		}
 		/*
 		this.launchedEffects = []
 		for(var e in getLaunchedEffects(id)){

--- a/Model/GameObject/EntityEffect
+++ b/Model/GameObject/EntityEffect
@@ -15,7 +15,7 @@ class EntityEffect {
 		this.turns = effect[3] as integer
 		// special case, infinite duration is ==-1, MUST handle this or any *duration later will inverse everything
 		// TODO use Scoring.getEffectiveDuration(this.turns, this.caster, this.target) once init order is verified
-		if(this.turns==-1) this.turns = Scoring.MAX_DURATION - 1
+		if(this.turns==-1) this.turns = ScoringConfig.MAX_DURATION - 1
 		this.critical = effect[4] as boolean
 		this.item = Items.getItem(effect[5] as integer)!
 		this.target = Fight.getEntity(effect[6] as integer)

--- a/Services/Benchmark
+++ b/Services/Benchmark
@@ -19,7 +19,11 @@ class Benchmark{
 	static _selfLife = 0
 	static _selfMaxLife = 0
 	static _selfTP = 0
+	static _selfMaxTP = 0
 	static _selfMP = 0
+	static _selfMaxMP = 0
+	static _selfUsedRAM = 0
+	static _selfMaxRAM = 0
 	static _selfCell = 0
 	static _enemies = 0
 	static _allies = 0
@@ -87,7 +91,11 @@ class Benchmark{
 		_selfLife = getLife()
 		_selfMaxLife = getTotalLife(getEntity())
 		_selfTP = getTP()
+		_selfMaxTP = getTotalTP(getEntity())
 		_selfMP = getMP()
+		_selfMaxMP = getTotalMP(getEntity())
+		_selfUsedRAM = getUsedRAM()
+		_selfMaxRAM = getMaxRAM()
 		_selfCell = getCell()
 		_enemies = count(getAliveEnemies())
 		_allies = count(getAliveAllies())
@@ -98,7 +106,11 @@ class Benchmark{
 		_selfLife = getLife()
 		_selfMaxLife = getTotalLife(getEntity())
 		_selfTP = getTP()
+		_selfMaxTP = getTotalTP(getEntity())
 		_selfMP = getMP()
+		_selfMaxMP = getTotalMP(getEntity())
+		_selfUsedRAM = getUsedRAM()
+		_selfMaxRAM = getMaxRAM()
 		_selfCell = getCell()
 		_enemies = count(getAliveEnemies())
 		_allies = count(getAliveAllies())
@@ -191,7 +203,9 @@ class Benchmark{
 		s += "|n:" + _name
 		s += "|o:" + totalOps + "/" + maxOps
 		s += "|hp:" + _selfLife + "/" + _selfMaxLife
-		s += "|tp:" + _selfTP + "|mp:" + _selfMP
+		// Use current values (after actions) for TP/MP/RAM to show what's remaining
+		s += "|tp:" + getTP() + "/" + getTotalTP(getEntity()) + "|mp:" + getMP() + "/" + getTotalMP(getEntity())
+		s += "|ram:" + getUsedRAM() + "/" + getMaxRAM()
 		s += "|c:" + _selfCell + "|e:" + _enemies + "|a:" + _allies
 		s += "|m:" + _mctsIter + "," + _mctsNodes + "," + _mctsPos + "," + _mctsBest
 		s += "|fc:" + funcCount  // Function count for verification

--- a/Services/Damages
+++ b/Services/Damages
@@ -46,7 +46,7 @@ class Damages{
 				dmg+= tmp>0?tmp:0
 			}
 			else if(e.type == EFFECT_POISON){
-				real duration = Scoring.defensive_duration_mitigation[e.duration]!
+				real duration = ScoringConfig.defensive_duration_mitigation[e.duration]!
 				// TODO if(_CAN_ANTIDOTE) duration = 1;
 				// TODO add consequences for pwr !
 				dmg += e.avgmax *(1+(eSource.getCurrentMgc(conseq))/100) *(1+(eSource.pwr/100)) *ratioDmg*duration

--- a/auto
+++ b/auto
@@ -32,6 +32,11 @@ include('Services/Sort')
 include('Services/Benchmark')
 
 
+include('AI/ScoringConfig')
+include('AI/EntityTypes')
+include('AI/EntityCoefs')
+include('AI/BattleState')
+include('AI/ScoringModifiers')
 include('AI/Scoring')
 include('AI/MCTS')
 include('AI/AI')
@@ -70,6 +75,9 @@ function init() {
 	Benchmark.start('MapDanger.refresh')
 	MapDanger.refresh()
 	Benchmark.stop('MapDanger.refresh')
+
+	// Compute ally danger after MapDanger (depends on danger maps)
+	BattleState.computeAllAllyDanger()
 
 	Benchmark.start('MapPosition.refresh')
 	MapPosition.refresh()

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -1,6 +1,6 @@
 # LeekWars Fight Analyzer
 
-A modular Tampermonkey userscript that provides AI debug visualization, profiler, and advanced statistics for LeekWars fight reports.
+A modular Tampermonkey userscript that provides AI debug visualization, profiler, and advanced statistics for LeekWars fight reports and fight pages.
 
 ## Features
 
@@ -11,6 +11,16 @@ A modular Tampermonkey userscript that provides AI debug visualization, profiler
 - **Resource tracking**: Monitor HP, TP, MP, cell position, and entity counts
 - **Action logs**: See movement, attacks, heals, buffs, and kills with structured formatting
 - **Native UI integration**: Seamlessly integrates with LeekWars' dark/light theme
+- **Fight page support**: View stats on `/fight/*` pages with a collapsible side panel
+- **Cache system**: Logs are cached in localStorage for viewing on fight pages
+- **Quick navigation**: Jump between report and fight pages with one click
+
+## Page Support
+
+| Page | Features |
+|------|----------|
+| **Report** (`/report/*`) | Full panel at bottom, logs cached automatically, button to view fight |
+| **Fight** (`/fight/*`) | Side panel (collapsible), toggle to bottom position, resizes combat player |
 
 ## Architecture
 
@@ -18,13 +28,15 @@ The script is split into 6 modular files for easier maintenance:
 
 ```
 tampermonkey/
-├── lwa-core.user.js      # Core: state, colors, helpers (~11KB)
-├── lwa-styles.user.js    # Styles: CSS only (~45KB)
-├── lwa-parser.user.js    # Parser: log parsing (~26KB)
-├── lwa-ui.user.js        # UI: rendering functions (~45KB)
-├── lwa-charts.user.js    # Charts: Chart.js + Analysis (~26KB)
-└── lwa-main.user.js      # Main: init + orchestration (~11KB)
+├── lwa-core.user.js      # Core: state, cache, settings, helpers
+├── lwa-styles.user.js    # Styles: CSS only
+├── lwa-parser.user.js    # Parser: log parsing
+├── lwa-ui.user.js        # UI: rendering, cache modal, side panel
+├── lwa-charts.user.js    # Charts: Chart.js + Analysis
+└── lwa-main.user.js      # Main: init + orchestration
 ```
+
+**Current versions**: All modules at v1.4.0 (except parser/charts at v1.1.0)
 
 **Load order**: The modules must load in this order (handled by `@run-at` directive):
 1. `lwa-core` (document-start) - Sets up shared namespace `unsafeWindow.LWA`
@@ -57,6 +69,33 @@ Install in this exact order:
 5. `lwa-charts.user.js`
 6. `lwa-main.user.js`
 
+## Cache System
+
+### How it works
+
+- When you visit a **report page**, logs are automatically saved to localStorage
+- When you visit a **fight page**, logs are loaded from the cache
+- If no cache exists for a fight, nothing is shown on the fight page
+- Cache is automatically cleaned up after 48 hours (configurable)
+
+### Cache Management
+
+Click the cache button in the panel header to:
+- View all cached fights with dates and sizes
+- Change the cache duration (default: 48 hours)
+- Manually cleanup old fights
+- Delete individual cached fights
+- Clear all cache
+
+## Fight Page Side Panel
+
+On fight pages, the analyzer displays as a **collapsible side panel**:
+
+- **Toggle button**: Chevron on the right edge to collapse/expand
+- **Position toggle**: Button in header to switch between side and bottom modes
+- **Responsive resize**: Combat player automatically resizes when panel opens/closes
+- **State persistence**: Panel position and collapsed state are saved in settings
+
 ## How It Works
 
 ### The Benchmark Protocol
@@ -64,7 +103,7 @@ Install in this exact order:
 The script parses structured debug output from the `Services/Benchmark` class in your LeekScript AI. The Benchmark class outputs a single `debug()` call at the end of each turn with a special marker format:
 
 ```
-##MARKER##T5|n:TagadaLive|o:45000/500000|hp:450/500|tp:8|mp:3|c:256|e:2|a:1|m:100,500,50,1234|ch:850,3,Flash(81)→Spark(120)→mv(256:180=0d+0p-57g+0t+0s)
+##MARKER##T5|n:TagadaLive|o:45000/500000|hp:450/500|tp:8|mp:3|c:256|e:2|a:1|m:100,500,50,1234|ch:850,3,Flash(81)->Spark(120)->mv(256:180=0d+0p-57g+0t+0s)
 ```
 
 ### Combo Description Format
@@ -72,7 +111,7 @@ The script parses structured debug output from the `Services/Benchmark` class in
 Actions and positions use a detailed format:
 
 ```
-Flash(81)→Spark(120)→mv(256:180=0d+0p-57g+0t+0s)
+Flash(81)->Spark(120)->mv(256:180=0d+0p-57g+0t+0s)
 ```
 
 Where:
@@ -99,8 +138,8 @@ Where:
 | `e:` | Enemy count | `e:2` |
 | `a:` | Ally count | `a:1` |
 | `m:` | MCTS stats (iter,nodes,pos,best) | `m:100,500,50,1234` |
-| `ch:` | Chosen combo (score,actions,desc) | `ch:850,3,Flash(81)→mv(256:...)` |
-| `cb:` | Top combo (score,actScore,posScore,desc) | `cb:900,600,300,Spark(120)→...` |
+| `ch:` | Chosen combo (score,actions,desc) | `ch:850,3,Flash(81)->mv(256:...)` |
+| `cb:` | Top combo (score,actScore,posScore,desc) | `cb:900,600,300,Spark(120)->...` |
 | `cat:` | Function category | `cat:MCTS` |
 | `f:` | Function stats (name,calls,total,pct,parent) | `f:AI.search,10,5000,11,` |
 | `l:` | Log entry | `l:Attack dealt 150 damage` |
@@ -169,18 +208,27 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 
 ## Viewing Results
 
+### On Report Page
 1. Run a fight (test or real)
-2. Open the fight report page
+2. Open the fight report page (`/report/{id}`)
 3. The analyzer panel appears below the fight replay
-4. Select your entity from the dropdown (if multiple)
-5. Use Prev/Next buttons to navigate turns
-6. Click on tabs to see Overview, Profiler, Combos, or Logs
+4. Logs are automatically cached for later viewing
+5. Click the play button to view the fight
+
+### On Fight Page
+1. Visit a fight page (`/fight/{id}`)
+2. If logs are cached, the side panel appears
+3. Use the chevron to collapse/expand the panel
+4. The combat player resizes automatically
+5. Use the position button to switch to bottom mode
 
 ## Module Details
 
 ### lwa-core.user.js
 - Shared namespace `unsafeWindow.LWA`
 - Global state management
+- **Cache system** (localStorage-based)
+- **User settings** (persistent, never auto-cleared)
 - Color palette
 - Helper functions (`fmt`, `pct`, `opsClass`, `formatComboDesc`)
 - Global onclick handlers
@@ -189,6 +237,9 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 - All CSS styles
 - LeekWars theme integration
 - Responsive layout rules
+- **Side panel styles** (fixed position, transitions)
+- **Toggle button styles**
+- Cache modal styles
 
 ### lwa-parser.user.js
 - `parseLogs()` - Main log parser
@@ -198,6 +249,7 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 
 ### lwa-ui.user.js
 - `createPanel()` - Panel creation
+- `injectPanel()` - Panel injection (bottom or side mode)
 - `render()` - Main render function
 - `renderOverview()` - Overview tab
 - `renderCombos()` - Combos tab
@@ -205,6 +257,8 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 - `renderLogs()` - Logs tab
 - `renderTimeline()` - Timeline tab
 - `renderAggregatedStats()` - Stats tab
+- **`openCacheModal()`** - Cache management modal
+- **Side panel toggle** - Collapse/expand with resize
 
 ### lwa-charts.user.js
 - `detectAnomalies()` - Anomaly detection
@@ -214,10 +268,28 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 - HP/Score chart visualizations
 
 ### lwa-main.user.js
-- `fetchLogs()` - Log fetching from DOM/Vue/API
+- `fetchLogs()` - Log fetching from DOM/Vue/Cache
 - `switchEntity()` - Entity switching
 - `injectJumpButtons()` - Turn jump buttons
-- `initAll()` - Application initialization
+- Page detection (`isReportPage`, `isFightPage`)
+- SPA navigation handling
+
+## Configuration
+
+### Settings (persisted in localStorage)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `fightPanelPosition` | `'side'` | Panel position on fight page (`'side'` or `'bottom'`) |
+| `fightPanelCollapsed` | `false` | Whether side panel is collapsed |
+
+### Cache Configuration
+
+| Config | Default | Description |
+|--------|---------|-------------|
+| `CACHE_MAX_AGE_HOURS` | `48` | Auto-cleanup after this many hours |
+| `MAX_FETCH_ATTEMPTS` | `2` | Number of retry attempts for loading logs |
+| `FETCH_RETRY_DELAY` | `1000` | Delay between retries (ms) |
 
 ## Screenshots
 
@@ -226,3 +298,4 @@ The analyzer integrates natively with LeekWars UI:
 - Uses familiar panel styling
 - Responsive grid layout for stats
 - Collapsible log categories
+- Side panel with smooth transitions on fight pages

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -12,7 +12,7 @@ A modular Tampermonkey userscript that provides AI debug visualization, profiler
 - **Resource charts**: Visualize HP%, TP Used%, MP Used%, and RAM Used% over time
 - **Action logs**: See movement, attacks, heals, buffs, and kills with structured formatting
 - **Native UI integration**: Seamlessly integrates with LeekWars' dark/light theme
-- **Fight page support**: View stats on `/fight/*` pages with a collapsible side panel
+- **Fight page support**: View stats on `/fight/*` pages with a resizable, collapsible side panel
 - **Cache system**: Logs are cached in localStorage for viewing on fight pages
 - **Quick navigation**: Jump between report and fight pages with one click
 
@@ -37,7 +37,7 @@ tampermonkey/
 └── lwa-main.user.js      # Main: init + orchestration
 ```
 
-**Current versions**: All modules at v1.4.0 (except parser/charts at v1.1.0)
+**Current versions**: Core/Styles/UI/Main at v1.5.0, Parser/Charts at v1.1.0
 
 **Load order**: The modules must load in this order (handled by `@run-at` directive):
 1. `lwa-core` (document-start) - Sets up shared namespace `unsafeWindow.LWA`
@@ -90,12 +90,16 @@ Click the cache button in the panel header to:
 
 ## Fight Page Side Panel
 
-On fight pages, the analyzer displays as a **collapsible side panel**:
+On fight pages, the analyzer displays as a **resizable, collapsible side panel**:
 
-- **Toggle button**: Chevron on the right edge to collapse/expand
+- **Toggle button**: Chevron on the right edge with multiple functions:
+  - **Click**: Collapse/expand the panel
+  - **Drag horizontally**: Resize the panel width (drag left = wider, drag right = narrower)
+  - **Double-click**: Reset to default width (400px)
+- **Width limits**: Min 280px, max 70% of screen or 800px
 - **Position toggle**: Button in header to switch between side and bottom modes
-- **Responsive resize**: Combat player automatically resizes when panel opens/closes
-- **State persistence**: Panel position and collapsed state are saved in settings
+- **Responsive resize**: Combat player automatically resizes when panel opens/closes or is resized
+- **State persistence**: Panel position, collapsed state, and custom width are saved in settings
 
 ## How It Works
 
@@ -220,7 +224,10 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 ### On Fight Page
 1. Visit a fight page (`/fight/{id}`)
 2. If logs are cached, the side panel appears
-3. Use the chevron to collapse/expand the panel
+3. Use the chevron button to:
+   - **Click**: Collapse/expand the panel
+   - **Drag**: Resize the panel width
+   - **Double-click**: Reset to default width
 4. The combat player resizes automatically
 5. Use the position button to switch to bottom mode
 
@@ -239,8 +246,8 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 - All CSS styles
 - LeekWars theme integration
 - Responsive layout rules
-- **Side panel styles** (fixed position, transitions)
-- **Toggle button styles**
+- **Side panel styles** (fixed position, transitions, CSS variable for width)
+- **Toggle button styles** (resize cursor, visual feedback)
 - Cache modal styles
 
 ### lwa-parser.user.js
@@ -260,7 +267,7 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 - `renderTimeline()` - Timeline tab
 - `renderAggregatedStats()` - Stats tab
 - **`openCacheModal()`** - Cache management modal
-- **Side panel toggle** - Collapse/expand with resize
+- **Side panel toggle** - Collapse/expand with drag-to-resize
 
 ### lwa-charts.user.js
 - `detectAnomalies()` - Anomaly detection
@@ -284,6 +291,7 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 |---------|---------|-------------|
 | `fightPanelPosition` | `'side'` | Panel position on fight page (`'side'` or `'bottom'`) |
 | `fightPanelCollapsed` | `false` | Whether side panel is collapsed |
+| `fightPanelWidth` | `400` | Custom width of side panel in pixels (280-800) |
 
 ### Cache Configuration
 

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -8,7 +8,8 @@ A modular Tampermonkey userscript that provides AI debug visualization, profiler
 - **Performance profiler**: See operation counts and percentages for each function, grouped by category
 - **MCTS visualization**: Track iterations, nodes explored, positions evaluated, and best scores
 - **Combo analysis**: View top-scored combos with action scores and position breakdown
-- **Resource tracking**: Monitor HP, TP, MP, cell position, and entity counts
+- **Resource tracking**: Monitor HP, TP, MP, RAM, cell position, and entity counts
+- **Resource charts**: Visualize HP%, TP Used%, MP Used%, and RAM Used% over time
 - **Action logs**: See movement, attacks, heals, buffs, and kills with structured formatting
 - **Native UI integration**: Seamlessly integrates with LeekWars' dark/light theme
 - **Fight page support**: View stats on `/fight/*` pages with a collapsible side panel
@@ -103,7 +104,7 @@ On fight pages, the analyzer displays as a **collapsible side panel**:
 The script parses structured debug output from the `Services/Benchmark` class in your LeekScript AI. The Benchmark class outputs a single `debug()` call at the end of each turn with a special marker format:
 
 ```
-##MARKER##T5|n:TagadaLive|o:45000/500000|hp:450/500|tp:8|mp:3|c:256|e:2|a:1|m:100,500,50,1234|ch:850,3,Flash(81)->Spark(120)->mv(256:180=0d+0p-57g+0t+0s)
+##MARKER##T5|n:TagadaLive|o:45000/500000|hp:450/500|tp:2/10|mp:1/4|ram:1500/3000|c:256|e:2|a:1|m:100,500,50,1234|ch:850,3,Flash(81)->Spark(120)->mv(256:180=0d+0p-57g+0t+0s)
 ```
 
 ### Combo Description Format
@@ -132,8 +133,9 @@ Where:
 | `n:` | Entity name | `n:TagadaLive` |
 | `o:` | Operations used/max | `o:45000/500000` |
 | `hp:` | Current/max health | `hp:450/500` |
-| `tp:` | Action points | `tp:8` |
-| `mp:` | Movement points | `mp:3` |
+| `tp:` | Remaining/max action points | `tp:2/10` |
+| `mp:` | Remaining/max movement points | `mp:1/4` |
+| `ram:` | Used/max RAM | `ram:1500/3000` |
 | `c:` | Cell position | `c:256` |
 | `e:` | Enemy count | `e:2` |
 | `a:` | Ally count | `a:1` |
@@ -263,9 +265,9 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 ### lwa-charts.user.js
 - `detectAnomalies()` - Anomaly detection
 - `renderAnalysis()` - Analysis tab
-- `initAnalysisCharts()` - Chart.js initialization
+- `renderAnalysisCharts()` - Chart.js initialization
 - `computeActionStats()` - Action statistics
-- HP/Score chart visualizations
+- **Charts**: HP%, Score, TP Used%, MP Used%, RAM Used%
 
 ### lwa-main.user.js
 - `fetchLogs()` - Log fetching from DOM/Vue/Cache

--- a/tampermonkey/lwa-charts.user.js
+++ b/tampermonkey/lwa-charts.user.js
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         LWA Charts
 // @namespace    https://leekwars.com/
-// @version      1.0.0
+// @version      1.1.0
 // @description  LeekWars Fight Analyzer - Charts module (Chart.js + Analysis)
 // @author       Sawdium
 // @match        https://leekwars.com/report/*
+// @match        https://leekwars.com/fight/*
 // @icon         https://leekwars.com/image/favicon.png
 // @grant        unsafeWindow
 // @inject-into  content

--- a/tampermonkey/lwa-core.user.js
+++ b/tampermonkey/lwa-core.user.js
@@ -309,7 +309,10 @@
     LWA.charts = {
         opsChart: null,
         hpChart: null,
-        scoreChart: null
+        scoreChart: null,
+        tpChart: null,
+        mpChart: null,
+        ramChart: null
     };
 
     // ========================================

--- a/tampermonkey/lwa-core.user.js
+++ b/tampermonkey/lwa-core.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         LWA Core
 // @namespace    https://leekwars.com/
-// @version      1.4.0
+// @version      1.5.0
 // @description  LeekWars Fight Analyzer - Core module (state, colors, helpers)
 // @author       Sawdium
 // @match        https://leekwars.com/report/*
@@ -23,7 +23,7 @@
     // Constants
     // ========================================
     LWA.MARKER = '##MARKER##';
-    LWA.VERSION = '1.4.0';
+    LWA.VERSION = '1.5.0';
     LWA.SUMMON_NAMES = ['Tourelle', 'Turret', 'Puny', 'Chest', 'Coffre'];
     LWA.MAX_FETCH_ATTEMPTS = 2;
     LWA.FETCH_RETRY_DELAY = 1000;
@@ -291,6 +291,7 @@
     // Setting keys
     LWA.SETTING_FIGHT_PANEL_POSITION = 'fightPanelPosition'; // 'bottom' or 'side'
     LWA.SETTING_FIGHT_PANEL_COLLAPSED = 'fightPanelCollapsed'; // true or false
+    LWA.SETTING_FIGHT_PANEL_WIDTH = 'fightPanelWidth'; // custom width in pixels (default: 400)
 
     // ========================================
     // Global State

--- a/tampermonkey/lwa-core.user.js
+++ b/tampermonkey/lwa-core.user.js
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         LWA Core
 // @namespace    https://leekwars.com/
-// @version      1.0.0
+// @version      1.4.0
 // @description  LeekWars Fight Analyzer - Core module (state, colors, helpers)
 // @author       Sawdium
 // @match        https://leekwars.com/report/*
+// @match        https://leekwars.com/fight/*
 // @icon         https://leekwars.com/image/favicon.png
 // @grant        unsafeWindow
 // @run-at       document-start
@@ -22,10 +23,274 @@
     // Constants
     // ========================================
     LWA.MARKER = '##MARKER##';
-    LWA.VERSION = '1.0.0';
+    LWA.VERSION = '1.4.0';
     LWA.SUMMON_NAMES = ['Tourelle', 'Turret', 'Puny', 'Chest', 'Coffre'];
-    LWA.MAX_FETCH_ATTEMPTS = 5;
-    LWA.FETCH_RETRY_DELAY = 2000;
+    LWA.MAX_FETCH_ATTEMPTS = 2;
+    LWA.FETCH_RETRY_DELAY = 1000;
+
+    // ========================================
+    // Cache Configuration
+    // ========================================
+    LWA.CACHE_PREFIX = 'lwa_fight_';
+    LWA.CACHE_INDEX_KEY = 'lwa_cache_index';
+    LWA.CACHE_MAX_AGE_HOURS = 48; // Default: auto-cleanup after 48 hours
+
+    // ========================================
+    // localStorage Cache System
+    // ========================================
+    LWA.cache = {
+        /**
+         * Save fight logs to localStorage
+         * @param {string|number} fightId - Fight ID
+         * @param {string} logs - Raw log text
+         */
+        save: function(fightId, logs) {
+            try {
+                const key = LWA.CACHE_PREFIX + fightId;
+                const data = {
+                    logs: logs,
+                    timestamp: Date.now(),
+                    fightId: fightId
+                };
+                localStorage.setItem(key, JSON.stringify(data));
+
+                // Update index
+                const index = LWA.cache.getIndex();
+                if (!index.includes(String(fightId))) {
+                    index.push(String(fightId));
+                    localStorage.setItem(LWA.CACHE_INDEX_KEY, JSON.stringify(index));
+                }
+                console.log(`[LWA Cache] Saved fight ${fightId} (${(logs.length / 1024).toFixed(1)} KB)`);
+            } catch (e) {
+                console.error('[LWA Cache] Error saving:', e);
+            }
+        },
+
+        /**
+         * Get fight logs from localStorage
+         * @param {string|number} fightId - Fight ID
+         * @returns {object|null} - { logs, timestamp, fightId } or null
+         */
+        get: function(fightId) {
+            try {
+                const key = LWA.CACHE_PREFIX + fightId;
+                const data = localStorage.getItem(key);
+                if (data) {
+                    const parsed = JSON.parse(data);
+                    console.log(`[LWA Cache] Loaded fight ${fightId} from cache`);
+                    return parsed;
+                }
+            } catch (e) {
+                console.error('[LWA Cache] Error loading:', e);
+            }
+            return null;
+        },
+
+        /**
+         * Check if fight is cached
+         * @param {string|number} fightId - Fight ID
+         * @returns {boolean}
+         */
+        has: function(fightId) {
+            return localStorage.getItem(LWA.CACHE_PREFIX + fightId) !== null;
+        },
+
+        /**
+         * Get cache index (list of cached fight IDs)
+         * @returns {string[]}
+         */
+        getIndex: function() {
+            try {
+                const index = localStorage.getItem(LWA.CACHE_INDEX_KEY);
+                return index ? JSON.parse(index) : [];
+            } catch (e) {
+                return [];
+            }
+        },
+
+        /**
+         * Get cache statistics
+         * @returns {object} - { count, totalSize, items }
+         */
+        getStats: function() {
+            const index = LWA.cache.getIndex();
+            let totalSize = 0;
+            const items = [];
+
+            for (const fightId of index) {
+                const key = LWA.CACHE_PREFIX + fightId;
+                const data = localStorage.getItem(key);
+                if (data) {
+                    const parsed = JSON.parse(data);
+                    const size = data.length;
+                    totalSize += size;
+                    items.push({
+                        fightId: fightId,
+                        timestamp: parsed.timestamp,
+                        size: size,
+                        age: Date.now() - parsed.timestamp
+                    });
+                }
+            }
+
+            // Sort by timestamp (newest first)
+            items.sort((a, b) => b.timestamp - a.timestamp);
+
+            return {
+                count: items.length,
+                totalSize: totalSize,
+                totalSizeKB: (totalSize / 1024).toFixed(1),
+                items: items
+            };
+        },
+
+        /**
+         * Remove old cached fights
+         * @param {number} maxAgeHours - Max age in hours (default: LWA.CACHE_MAX_AGE_HOURS)
+         * @returns {number} - Number of items removed
+         */
+        cleanup: function(maxAgeHours) {
+            const maxAge = (maxAgeHours || LWA.CACHE_MAX_AGE_HOURS) * 60 * 60 * 1000;
+            const now = Date.now();
+            const index = LWA.cache.getIndex();
+            const newIndex = [];
+            let removed = 0;
+
+            for (const fightId of index) {
+                const key = LWA.CACHE_PREFIX + fightId;
+                const data = localStorage.getItem(key);
+                if (data) {
+                    try {
+                        const parsed = JSON.parse(data);
+                        if (now - parsed.timestamp > maxAge) {
+                            localStorage.removeItem(key);
+                            removed++;
+                            console.log(`[LWA Cache] Removed old fight ${fightId}`);
+                        } else {
+                            newIndex.push(fightId);
+                        }
+                    } catch (e) {
+                        localStorage.removeItem(key);
+                        removed++;
+                    }
+                }
+            }
+
+            localStorage.setItem(LWA.CACHE_INDEX_KEY, JSON.stringify(newIndex));
+            if (removed > 0) {
+                console.log(`[LWA Cache] Cleanup: removed ${removed} old fights`);
+            }
+            return removed;
+        },
+
+        /**
+         * Clear all cached fights
+         * @returns {number} - Number of items removed
+         */
+        clear: function() {
+            const index = LWA.cache.getIndex();
+            let removed = 0;
+
+            for (const fightId of index) {
+                const key = LWA.CACHE_PREFIX + fightId;
+                localStorage.removeItem(key);
+                removed++;
+            }
+
+            localStorage.removeItem(LWA.CACHE_INDEX_KEY);
+            console.log(`[LWA Cache] Cleared ${removed} fights`);
+            return removed;
+        },
+
+        /**
+         * Remove a specific fight from cache
+         * @param {string|number} fightId - Fight ID
+         */
+        remove: function(fightId) {
+            const key = LWA.CACHE_PREFIX + fightId;
+            localStorage.removeItem(key);
+
+            const index = LWA.cache.getIndex();
+            const newIndex = index.filter(id => id !== String(fightId));
+            localStorage.setItem(LWA.CACHE_INDEX_KEY, JSON.stringify(newIndex));
+            console.log(`[LWA Cache] Removed fight ${fightId}`);
+        },
+
+        /**
+         * Set max age for auto-cleanup
+         * @param {number} hours - Max age in hours
+         */
+        setMaxAge: function(hours) {
+            LWA.CACHE_MAX_AGE_HOURS = hours;
+            localStorage.setItem('lwa_cache_max_age', hours);
+            console.log(`[LWA Cache] Max age set to ${hours} hours`);
+        },
+
+        /**
+         * Get max age setting
+         * @returns {number}
+         */
+        getMaxAge: function() {
+            try {
+                const saved = localStorage.getItem('lwa_cache_max_age');
+                if (saved) {
+                    LWA.CACHE_MAX_AGE_HOURS = parseInt(saved);
+                }
+            } catch (e) {}
+            return LWA.CACHE_MAX_AGE_HOURS;
+        }
+    };
+
+    // Initialize and run auto-cleanup on load
+    LWA.cache.getMaxAge();
+    LWA.cache.cleanup();
+
+    // ========================================
+    // User Settings (persisted, never auto-cleared)
+    // ========================================
+    LWA.SETTINGS_KEY = 'lwa_settings';
+
+    LWA.settings = {
+        /**
+         * Get all settings
+         * @returns {object}
+         */
+        getAll: function() {
+            try {
+                const saved = localStorage.getItem(LWA.SETTINGS_KEY);
+                return saved ? JSON.parse(saved) : {};
+            } catch (e) {
+                return {};
+            }
+        },
+
+        /**
+         * Get a specific setting
+         * @param {string} key - Setting key
+         * @param {*} defaultValue - Default value if not set
+         * @returns {*}
+         */
+        get: function(key, defaultValue) {
+            const all = LWA.settings.getAll();
+            return all.hasOwnProperty(key) ? all[key] : defaultValue;
+        },
+
+        /**
+         * Set a specific setting
+         * @param {string} key - Setting key
+         * @param {*} value - Value to save
+         */
+        set: function(key, value) {
+            const all = LWA.settings.getAll();
+            all[key] = value;
+            localStorage.setItem(LWA.SETTINGS_KEY, JSON.stringify(all));
+            console.log(`[LWA Settings] ${key} = ${value}`);
+        }
+    };
+
+    // Setting keys
+    LWA.SETTING_FIGHT_PANEL_POSITION = 'fightPanelPosition'; // 'bottom' or 'side'
+    LWA.SETTING_FIGHT_PANEL_COLLAPSED = 'fightPanelCollapsed'; // true or false
 
     // ========================================
     // Global State

--- a/tampermonkey/lwa-main.user.js
+++ b/tampermonkey/lwa-main.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         LWA Main
 // @namespace    https://leekwars.com/
-// @version      1.4.0
+// @version      1.5.0
 // @description  LeekWars Fight Analyzer - Main module (init + orchestration)
 // @author       Sawdium
 // @match        https://leekwars.com/report/*

--- a/tampermonkey/lwa-main.user.js
+++ b/tampermonkey/lwa-main.user.js
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         LWA Main
 // @namespace    https://leekwars.com/
-// @version      1.0.0
+// @version      1.4.0
 // @description  LeekWars Fight Analyzer - Main module (init + orchestration)
 // @author       Sawdium
 // @match        https://leekwars.com/report/*
+// @match        https://leekwars.com/fight/*
 // @icon         https://leekwars.com/image/favicon.png
 // @grant        unsafeWindow
 // @inject-into  content
@@ -41,94 +42,113 @@
             LWA.state.fetchAttempts = 0;
         }
         LWA.state.fetchAttempts++;
-        console.log(`[LWA] Looking for logs... (attempt ${LWA.state.fetchAttempts}/${LWA.MAX_FETCH_ATTEMPTS})`);
+
+        const fightId = LWA.getFightId();
+        LWA.state.currentFightId = fightId;
+        LWA.state.isFromCache = false;
+
+        console.log(`[LWA] Looking for logs... (attempt ${LWA.state.fetchAttempts}/${LWA.MAX_FETCH_ATTEMPTS}, fightId: ${fightId})`);
 
         let allLogs = '';
         let foundLogs = false;
 
-        // DOM selectors
-        const sels = ['.logs-content', '.log-content', '.fight-logs', '.logs', '[class*="log"]', 'pre'];
-        for (const s of sels) {
-            document.querySelectorAll(s).forEach(el => {
-                const text = el.textContent || '';
-                if (text.length > 0) {
-                    allLogs += text + '\n';
-                    foundLogs = true;
-                }
-            });
-        }
-
-        // Vue data - try multiple approaches
-        const app = document.querySelector('#app');
-        if (app) {
-            // Try Vue 2 style
-            if (app.__vue__) {
-                try {
-                    const vue = app.__vue__;
-                    const fight = vue.$store?.state?.fight || vue.fight || vue.$data?.fight;
-                    if (fight?.logs) {
-                        console.log('[LWA] Found logs via Vue 2');
-                        for (const id in fight.logs) {
-                            if (Array.isArray(fight.logs[id])) {
-                                allLogs += fight.logs[id].join('\n') + '\n';
-                                foundLogs = true;
-                            }
-                        }
-                    }
-                } catch (e) {
-                    console.log('[LWA] Vue 2 access error:', e);
-                }
-            }
-
-            // Try Vue 3 style
-            if (app._instance?.proxy) {
-                try {
-                    const proxy = app._instance.proxy;
-                    const fight = proxy.fight || proxy.$store?.state?.fight;
-                    if (fight?.logs) {
-                        console.log('[LWA] Found logs via Vue 3');
-                        for (const id in fight.logs) {
-                            if (Array.isArray(fight.logs[id])) {
-                                allLogs += fight.logs[id].join('\n') + '\n';
-                                foundLogs = true;
-                            }
-                        }
-                    }
-                } catch (e) {
-                    console.log('[LWA] Vue 3 access error:', e);
-                }
+        // On fight page, try to load from cache first
+        if (LWA.isFightPage() && fightId && LWA.cache.has(fightId)) {
+            const cached = LWA.cache.get(fightId);
+            if (cached && cached.logs) {
+                allLogs = cached.logs;
+                foundLogs = true;
+                LWA.state.isFromCache = true;
+                console.log('[LWA] Loaded logs from cache');
             }
         }
 
-        // Try fetching from API if we have the fight ID
-        const fightIdMatch = location.pathname.match(/\/report\/(\d+)/);
-        if (!foundLogs && fightIdMatch) {
-            const fightId = fightIdMatch[1];
-            console.log(`[LWA] Attempting to fetch fight ${fightId} from API...`);
+        // If not from cache, try to get from DOM/Vue (only works on report page)
+        if (!foundLogs) {
+            // DOM selectors
+            const sels = ['.logs-content', '.log-content', '.fight-logs', '.logs', '[class*="log"]', 'pre'];
+            for (const s of sels) {
+                document.querySelectorAll(s).forEach(el => {
+                    const text = el.textContent || '';
+                    if (text.length > 0) {
+                        allLogs += text + '\n';
+                        foundLogs = true;
+                    }
+                });
+            }
 
-            // Try to get logs from localStorage or sessionStorage
-            try {
-                const cachedFight = sessionStorage.getItem(`fight_${fightId}`) || localStorage.getItem(`fight_${fightId}`);
-                if (cachedFight) {
-                    const fight = JSON.parse(cachedFight);
-                    if (fight?.logs) {
-                        for (const id in fight.logs) {
-                            if (Array.isArray(fight.logs[id])) {
-                                allLogs += fight.logs[id].join('\n') + '\n';
-                                foundLogs = true;
+            // Vue data - try multiple approaches
+            const app = document.querySelector('#app');
+            if (app) {
+                // Try Vue 2 style
+                if (app.__vue__) {
+                    try {
+                        const vue = app.__vue__;
+                        const fight = vue.$store?.state?.fight || vue.fight || vue.$data?.fight;
+                        if (fight?.logs) {
+                            console.log('[LWA] Found logs via Vue 2');
+                            for (const id in fight.logs) {
+                                if (Array.isArray(fight.logs[id])) {
+                                    allLogs += fight.logs[id].join('\n') + '\n';
+                                    foundLogs = true;
+                                }
                             }
                         }
+                    } catch (e) {
+                        console.log('[LWA] Vue 2 access error:', e);
                     }
                 }
-            } catch (e) { /* ignore */ }
+
+                // Try Vue 3 style
+                if (app._instance?.proxy) {
+                    try {
+                        const proxy = app._instance.proxy;
+                        const fight = proxy.fight || proxy.$store?.state?.fight;
+                        if (fight?.logs) {
+                            console.log('[LWA] Found logs via Vue 3');
+                            for (const id in fight.logs) {
+                                if (Array.isArray(fight.logs[id])) {
+                                    allLogs += fight.logs[id].join('\n') + '\n';
+                                    foundLogs = true;
+                                }
+                            }
+                        }
+                    } catch (e) {
+                        console.log('[LWA] Vue 3 access error:', e);
+                    }
+                }
+            }
         }
 
         const hasMarkerData = allLogs.includes(MARKER);
         const hasErrorData = allLogs.includes('Interruption de l\'IA') || allLogs.includes('AI interrupted');
 
-        console.log(`[LWA] Logs found: ${foundLogs}, Marker data: ${hasMarkerData}, Error data: ${hasErrorData}`);
+        console.log(`[LWA] Logs found: ${foundLogs}, Marker data: ${hasMarkerData}, Error data: ${hasErrorData}, allLogs length: ${allLogs.length}`);
 
-        if (hasMarkerData || hasErrorData) {
+        // On fight page without cache, the logs appear progressively during replay
+        // Check DOM for <pre> tags that might contain marker data (shown during fight playback)
+        if (!hasMarkerData && !hasErrorData && LWA.isFightPage()) {
+            const preTags = document.querySelectorAll('pre');
+            for (const pre of preTags) {
+                const text = pre.textContent || '';
+                if (text.includes(MARKER)) {
+                    console.log('[LWA] Found marker in pre tag during fight playback');
+                    allLogs += text + '\n';
+                    break;
+                }
+            }
+        }
+
+        // Re-check after additional pre tag search
+        const hasMarkerDataFinal = allLogs.includes(MARKER);
+        const hasErrorDataFinal = allLogs.includes('Interruption de l\'IA') || allLogs.includes('AI interrupted');
+
+        if (hasMarkerDataFinal || hasErrorDataFinal) {
+            // Save to cache if we're on the report page and got fresh data
+            if (LWA.isReportPage() && fightId && !LWA.state.isFromCache && allLogs.length > 0) {
+                LWA.cache.save(fightId, allLogs);
+            }
+
             LWA.state.entitiesData = LWA.parseLogs(allLogs);
             const entityNames = Object.keys(LWA.state.entitiesData);
             console.log('[LWA] Found entities:', entityNames);
@@ -149,17 +169,21 @@
             LWA.state.currentIdx = 0;
             LWA.render();
 
-            // Inject jump buttons into LeekWars turn headers
-            setTimeout(LWA.injectJumpButtons, 500);
-        } else if (LWA.state.fetchAttempts < LWA.MAX_FETCH_ATTEMPTS) {
-            // Retry after delay - data might not be loaded yet
-            console.log(`[LWA] No data found, retrying in ${LWA.FETCH_RETRY_DELAY}ms...`);
-            setTimeout(() => LWA.fetchLogs(true), LWA.FETCH_RETRY_DELAY);
+            // Inject jump buttons into LeekWars turn headers (only on report page)
+            if (LWA.isReportPage()) {
+                setTimeout(LWA.injectJumpButtons, 500);
+            }
         } else {
-            // Max attempts reached, show no data state
-            console.log('[LWA] Max fetch attempts reached, showing no data state');
-            LWA.state.currentIdx = 0;
-            LWA.render();
+            // Retry logic - cache is checked instantly, so few retries needed
+            if (LWA.state.fetchAttempts < LWA.MAX_FETCH_ATTEMPTS) {
+                console.log(`[LWA] No data found, retrying in ${LWA.FETCH_RETRY_DELAY}ms... (attempt ${LWA.state.fetchAttempts}/${LWA.MAX_FETCH_ATTEMPTS})`);
+                setTimeout(() => LWA.fetchLogs(true), LWA.FETCH_RETRY_DELAY);
+            } else {
+                // Max attempts reached, show no data state
+                console.log('[LWA] Max fetch attempts reached, showing no data state');
+                LWA.state.currentIdx = 0;
+                LWA.render();
+            }
         }
     }
 
@@ -173,11 +197,23 @@
     }
 
     // ========================================
-    // Init
+    // Page Detection
     // ========================================
     LWA.isReportPage = function() {
         return /\/report\/\d+/.test(location.pathname);
     }
+
+    LWA.isFightPage = function() {
+        return /\/fight\/\d+/.test(location.pathname);
+    }
+
+    LWA.getFightId = function() {
+        const match = location.pathname.match(/\/(?:report|fight)\/(\d+)/);
+        return match ? match[1] : null;
+    }
+
+    LWA.state.isFromCache = false; // Track if current data is from cache
+    LWA.state.currentFightId = null;
 
     LWA.waitForElement = function(selector, timeout = 10000) {
         return new Promise((resolve, reject) => {
@@ -204,8 +240,12 @@
         });
     }
 
-    async function initializeOnReportPage() {
-        console.log('[LWA] Initializing on report page...');
+    async function initializePage() {
+        const isReport = LWA.isReportPage();
+        const isFight = LWA.isFightPage();
+        const fightId = LWA.getFightId();
+
+        console.log(`[LWA] Initializing on ${isReport ? 'report' : 'fight'} page (fight ${fightId})...`);
 
         // Reset state
         LWA.state.entitiesData = {};
@@ -213,9 +253,13 @@
         LWA.state.turnData = [];
         LWA.state.currentIdx = 0;
         LWA.state.fetchAttempts = 0;
+        LWA.state.isFromCache = false;
+        LWA.state.currentFightId = fightId;
+
+        // On fight page without cached data, nothing will be shown (handled in injectPanel)
 
         // Wait for the page structure to be ready
-        const pageReady = await LWA.waitForElement('.report, .report-page, .page-content, .panel', 8000);
+        const pageReady = await LWA.waitForElement('.report, .report-page, .fight, .fight-page, .page-content, .panel', 8000);
 
         if (!pageReady) {
             console.log('[LWA] Page structure not found after timeout, attempting anyway...');
@@ -226,22 +270,22 @@
 
         // Wait a bit more for fight data to load, then fetch logs
         // LeekWars loads fight data asynchronously
-        setTimeout(LWA.fetchLogs, 1500);
+        setTimeout(LWA.fetchLogs, isReport ? 1500 : 500);
     }
 
     function init() {
         // Styles are loaded by lwa-styles.user.js module
         console.log('%c[LWA] Fight Analyzer v' + LWA.VERSION + ' loaded', 'color: #5cad4a; font-weight: bold;');
 
-        // Only initialize panel on report pages
-        if (LWA.isReportPage()) {
+        // Initialize panel on report or fight pages
+        if (LWA.isReportPage() || LWA.isFightPage()) {
             // Wait for DOM to be ready
             if (document.readyState === 'loading') {
                 document.addEventListener('DOMContentLoaded', () => {
-                    setTimeout(initializeOnReportPage, 500);
+                    setTimeout(initializePage, 500);
                 });
             } else {
-                setTimeout(initializeOnReportPage, 500);
+                setTimeout(initializePage, 500);
             }
         }
 
@@ -258,16 +302,16 @@
                     clearTimeout(navigationTimeout);
                 }
 
-                if (LWA.isReportPage()) {
-                    // Navigated to a report page - wait a bit then initialize
-                    console.log('[LWA] Navigated to report page, initializing...');
-                    navigationTimeout = setTimeout(initializeOnReportPage, 1000);
+                if (LWA.isReportPage() || LWA.isFightPage()) {
+                    // Navigated to a report/fight page - wait a bit then initialize
+                    console.log('[LWA] Navigated to report/fight page, initializing...');
+                    navigationTimeout = setTimeout(initializePage, 1000);
                 } else {
-                    // Left report page - remove the panel
+                    // Left report/fight page - remove the panel
                     const panel = document.querySelector('.lwa-panel');
                     if (panel) {
                         panel.remove();
-                        console.log('[LWA] Panel removed (left report page)');
+                        console.log('[LWA] Panel removed (left report/fight page)');
                     }
                 }
             }
@@ -276,10 +320,10 @@
         // Also listen for popstate (browser back/forward)
         window.addEventListener('popstate', () => {
             setTimeout(() => {
-                if (LWA.isReportPage()) {
+                if (LWA.isReportPage() || LWA.isFightPage()) {
                     const existing = document.querySelector('.lwa-panel');
                     if (!existing) {
-                        initializeOnReportPage();
+                        initializePage();
                     }
                 }
             }, 500);

--- a/tampermonkey/lwa-parser.user.js
+++ b/tampermonkey/lwa-parser.user.js
@@ -261,7 +261,7 @@
         const turn = {
             t: 0,
             ops: 0, max: 0,
-            ctx: { life: 0, maxLife: 0, tp: 0, mp: 0, cell: 0, enemies: 0, allies: 0 },
+            ctx: { life: 0, maxLife: 0, tp: 0, maxTp: 0, mp: 0, maxMp: 0, usedRam: 0, maxRam: 0, cell: 0, enemies: 0, allies: 0 },
             mcts: { iter: 0, nodes: 0, pos: 0, best: 0 },
             chosen: { score: 0, actions: 0, desc: '' },
             combos: [],
@@ -286,10 +286,28 @@
                 if (m) { turn.ctx.life = parseInt(m[1]); turn.ctx.maxLife = parseInt(m[2]); }
             }
             else if (p.startsWith('tp:')) {
-                turn.ctx.tp = parseInt(p.substring(3)) || 0;
+                // Format: tp:current/max or legacy tp:current
+                const tpMatch = p.match(/tp:(\d+)(?:\/(\d+))?/);
+                if (tpMatch) {
+                    turn.ctx.tp = parseInt(tpMatch[1]) || 0;
+                    turn.ctx.maxTp = parseInt(tpMatch[2]) || turn.ctx.tp;
+                }
             }
             else if (p.startsWith('mp:')) {
-                turn.ctx.mp = parseInt(p.substring(3)) || 0;
+                // Format: mp:current/max or legacy mp:current
+                const mpMatch = p.match(/mp:(\d+)(?:\/(\d+))?/);
+                if (mpMatch) {
+                    turn.ctx.mp = parseInt(mpMatch[1]) || 0;
+                    turn.ctx.maxMp = parseInt(mpMatch[2]) || turn.ctx.mp;
+                }
+            }
+            else if (p.startsWith('ram:')) {
+                // Format: ram:used/max
+                const ramMatch = p.match(/ram:(\d+)\/(\d+)/);
+                if (ramMatch) {
+                    turn.ctx.usedRam = parseInt(ramMatch[1]) || 0;
+                    turn.ctx.maxRam = parseInt(ramMatch[2]) || 0;
+                }
             }
             else if (p.startsWith('c:')) {
                 turn.ctx.cell = parseInt(p.substring(2)) || 0;
@@ -427,7 +445,7 @@
                 t: d.t || 0,
                 ops: d.ops || 0,
                 max: d.max || 0,
-                ctx: d.ctx || { life: 0, maxLife: 0, tp: 0, mp: 0, cell: 0, enemies: 0, allies: 0 },
+                ctx: d.ctx || { life: 0, maxLife: 0, tp: 0, maxTp: 0, mp: 0, maxMp: 0, usedRam: 0, maxRam: 0, cell: 0, enemies: 0, allies: 0 },
                 mcts: d.mcts || { iter: 0, nodes: 0, pos: 0, best: 0 },
                 chosen: d.chosen || { score: 0, actions: 0, desc: '' },
                 combos: (d.combos || []).map(c => ({ s: c.s, as: c.as, ps: c.ps, d: c.d })),

--- a/tampermonkey/lwa-parser.user.js
+++ b/tampermonkey/lwa-parser.user.js
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         LWA Parser
 // @namespace    https://leekwars.com/
-// @version      1.0.0
+// @version      1.1.0
 // @description  LeekWars Fight Analyzer - Parser module (log parsing)
 // @author       Sawdium
 // @match        https://leekwars.com/report/*
+// @match        https://leekwars.com/fight/*
 // @icon         https://leekwars.com/image/favicon.png
 // @grant        unsafeWindow
 // @inject-into  content

--- a/tampermonkey/lwa-styles.user.js
+++ b/tampermonkey/lwa-styles.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         LWA Styles
 // @namespace    https://leekwars.com/
-// @version      1.4.0
+// @version      1.5.0
 // @description  LeekWars Fight Analyzer - Styles module (CSS only)
 // @author       Sawdium
 // @match        https://leekwars.com/report/*
@@ -1749,8 +1749,13 @@
 
         /* Force width constraint when LWA panel is open */
         .app-center.lwa-panel-open {
-            width: calc(100vw - 400px - 60px) !important; /* 400px panel + ~60px left sidebar */
-            max-width: calc(100vw - 400px - 60px) !important;
+            width: calc(100vw - var(--lwa-panel-width, 400px) - 60px) !important; /* panel + ~60px left sidebar */
+            max-width: calc(100vw - var(--lwa-panel-width, 400px) - 60px) !important;
+        }
+
+        /* Disable transition during resize for smooth dragging */
+        .app-center.lwa-resizing {
+            transition: none !important;
         }
 
         /* Also constrain the fight player and page content directly */
@@ -1761,20 +1766,6 @@
         .app-center.lwa-panel-open .combat {
             max-width: 100% !important;
             width: auto !important;
-        }
-
-        @media (max-width: 1400px) {
-            .app-center.lwa-panel-open {
-                width: calc(100vw - 350px - 60px) !important;
-                max-width: calc(100vw - 350px - 60px) !important;
-            }
-        }
-
-        @media (max-width: 1100px) {
-            .app-center.lwa-panel-open {
-                width: calc(100vw - 300px - 60px) !important;
-                max-width: calc(100vw - 300px - 60px) !important;
-            }
         }
 
         @media (max-width: 900px) {
@@ -1789,13 +1780,20 @@
             position: fixed !important;
             right: 0;
             top: 60px;
-            width: 400px;
+            width: var(--lwa-panel-width, 400px);
+            min-width: 280px;
+            max-width: 70vw;
             height: calc(100vh - 60px);
             overflow-y: auto;
             overflow-x: hidden;
             z-index: 900;
             margin: 0 !important;
             transition: transform 0.3s ease, opacity 0.3s ease;
+        }
+
+        /* Disable transition during resize for smooth dragging */
+        .lwa-panel-side.lwa-resizing {
+            transition: none !important;
         }
 
         .lwa-panel-side .panel {
@@ -1816,10 +1814,59 @@
             pointer-events: none;
         }
 
+        /* Resize handle - left edge of side panel */
+        .lwa-resize-handle {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 6px;
+            height: 100%;
+            cursor: ew-resize;
+            background: transparent;
+            z-index: 1002;
+            transition: background 0.2s;
+        }
+
+        .lwa-resize-handle:hover,
+        .lwa-resize-handle.active {
+            background: linear-gradient(90deg, #5fad1b 0%, transparent 100%);
+        }
+
+        .lwa-resize-handle::before {
+            content: '';
+            position: absolute;
+            left: 1px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 3px;
+            height: 40px;
+            background: rgba(255,255,255,0.2);
+            border-radius: 2px;
+            opacity: 0;
+            transition: opacity 0.2s;
+        }
+
+        .lwa-resize-handle:hover::before,
+        .lwa-resize-handle.active::before {
+            opacity: 1;
+            background: rgba(255,255,255,0.5);
+        }
+
+        /* Prevent text selection during resize */
+        body.lwa-resizing-active {
+            user-select: none !important;
+            cursor: ew-resize !important;
+        }
+
+        body.lwa-resizing-active * {
+            cursor: ew-resize !important;
+        }
+
         /* Side toggle button - fixed position so it stays visible */
+        /* Also acts as resize handle when dragged */
         .lwa-side-toggle {
             position: fixed;
-            right: 400px;
+            right: var(--lwa-panel-width, 400px);
             top: 50%;
             transform: translateY(-50%);
             width: 28px;
@@ -1829,16 +1876,28 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            cursor: pointer;
+            cursor: ew-resize;
             z-index: 1001;
-            transition: right 0.3s ease, background 0.15s;
+            transition: right 0.3s ease, background 0.15s, box-shadow 0.15s;
             box-shadow: -3px 0 10px rgba(0,0,0,0.4);
             border: 1px solid rgba(255,255,255,0.1);
             border-right: none;
         }
 
+        /* Disable transition during resize for smooth dragging */
+        .lwa-side-toggle.lwa-resizing {
+            transition: none !important;
+            background: linear-gradient(180deg, #5fad1b 0%, #4a8a15 100%) !important;
+            box-shadow: -3px 0 15px rgba(95,173,27,0.5) !important;
+        }
+
         .lwa-side-toggle:hover {
             background: linear-gradient(180deg, #3a3a3a 0%, #2a2a2a 100%);
+            box-shadow: -3px 0 15px rgba(95,173,27,0.3);
+        }
+
+        .lwa-side-toggle:active {
+            background: linear-gradient(180deg, #5fad1b 0%, #4a8a15 100%);
         }
 
         .lwa-side-toggle i {
@@ -1848,6 +1907,7 @@
 
         .lwa-side-toggle.lwa-toggle-collapsed {
             right: 0;
+            cursor: pointer; /* Only click to expand when collapsed */
         }
 
         /* Adjust side panel header for compact display */
@@ -1866,35 +1926,11 @@
             padding: 10px;
         }
 
-        /* Responsive adjustments for side mode */
-        @media (max-width: 1400px) {
-            .lwa-panel-side {
-                width: 350px;
-            }
-            .lwa-side-toggle {
-                right: 350px;
-            }
-            .lwa-side-toggle.lwa-toggle-collapsed {
-                right: 0;
-            }
-        }
-
-        @media (max-width: 1100px) {
-            .lwa-panel-side {
-                width: 300px;
-            }
-            .lwa-side-toggle {
-                right: 300px;
-            }
-            .lwa-side-toggle.lwa-toggle-collapsed {
-                right: 0;
-            }
-        }
-
+        /* Responsive adjustments for side mode - mobile: switch to bottom mode */
         @media (max-width: 900px) {
             .lwa-panel-side {
                 position: relative !important;
-                width: 100%;
+                width: 100% !important;
                 height: auto;
                 max-height: none;
                 top: auto;
@@ -1918,6 +1954,10 @@
             }
             .lwa-side-toggle.lwa-toggle-collapsed {
                 right: auto;
+            }
+            /* Hide resize handle on mobile */
+            .lwa-resize-handle {
+                display: none;
             }
         }
 

--- a/tampermonkey/lwa-styles.user.js
+++ b/tampermonkey/lwa-styles.user.js
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         LWA Styles
 // @namespace    https://leekwars.com/
-// @version      1.0.0
+// @version      1.4.0
 // @description  LeekWars Fight Analyzer - Styles module (CSS only)
 // @author       Sawdium
 // @match        https://leekwars.com/report/*
+// @match        https://leekwars.com/fight/*
 // @icon         https://leekwars.com/image/favicon.png
 // @grant        GM_addStyle
 // @grant        unsafeWindow
@@ -1675,6 +1676,517 @@
 
         .lwa-tl-turn:hover .lwa-tl-events {
             border-color: #5fad1b;
+        }
+
+        /* ===== HEADER ACTIONS ===== */
+        .lwa-header-actions {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-right: 12px;
+        }
+
+        .lwa-header-btn {
+            background: rgba(255,255,255,0.1);
+            border: 1px solid rgba(255,255,255,0.2);
+            color: #eee;
+            padding: 4px 8px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.15s;
+            text-decoration: none;
+        }
+
+        .lwa-header-btn:hover {
+            background: rgba(255,255,255,0.2);
+            border-color: rgba(255,255,255,0.3);
+        }
+
+        .lwa-cache-btn {
+            background: rgba(255,255,255,0.1);
+            border: 1px solid rgba(255,255,255,0.2);
+            color: #eee;
+            padding: 4px 10px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 12px;
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            transition: all 0.15s;
+        }
+
+        .lwa-cache-btn:hover {
+            background: rgba(255,255,255,0.2);
+            border-color: rgba(255,255,255,0.3);
+        }
+
+        .lwa-cache-count {
+            background: #5fad1b;
+            color: #fff;
+            padding: 1px 6px;
+            border-radius: 10px;
+            font-size: 10px;
+            font-weight: 600;
+        }
+
+        .lwa-cache-badge {
+            margin-left: 6px;
+            font-size: 12px;
+            cursor: help;
+        }
+
+        /* ===== FIGHT PAGE SIDE MODE ===== */
+
+        /* Main content width transition */
+        .app-center {
+            transition: width 0.3s ease, max-width 0.3s ease !important;
+        }
+
+        /* Force width constraint when LWA panel is open */
+        .app-center.lwa-panel-open {
+            width: calc(100vw - 400px - 60px) !important; /* 400px panel + ~60px left sidebar */
+            max-width: calc(100vw - 400px - 60px) !important;
+        }
+
+        /* Also constrain the fight player and page content directly */
+        .app-center.lwa-panel-open .page,
+        .app-center.lwa-panel-open .page-content,
+        .app-center.lwa-panel-open .fight,
+        .app-center.lwa-panel-open .fight-page,
+        .app-center.lwa-panel-open .combat {
+            max-width: 100% !important;
+            width: auto !important;
+        }
+
+        @media (max-width: 1400px) {
+            .app-center.lwa-panel-open {
+                width: calc(100vw - 350px - 60px) !important;
+                max-width: calc(100vw - 350px - 60px) !important;
+            }
+        }
+
+        @media (max-width: 1100px) {
+            .app-center.lwa-panel-open {
+                width: calc(100vw - 300px - 60px) !important;
+                max-width: calc(100vw - 300px - 60px) !important;
+            }
+        }
+
+        @media (max-width: 900px) {
+            .app-center.lwa-panel-open {
+                width: 100% !important;
+                max-width: 100% !important;
+            }
+        }
+
+        /* Side panel - fixed position on right side */
+        .lwa-panel-side {
+            position: fixed !important;
+            right: 0;
+            top: 60px;
+            width: 400px;
+            height: calc(100vh - 60px);
+            overflow-y: auto;
+            overflow-x: hidden;
+            z-index: 900;
+            margin: 0 !important;
+            transition: transform 0.3s ease, opacity 0.3s ease;
+        }
+
+        .lwa-panel-side .panel {
+            border-radius: 4px 0 0 4px;
+            margin: 0;
+            min-height: 100%;
+        }
+
+        .lwa-panel-side .panel .header {
+            position: sticky;
+            top: 0;
+            z-index: 10;
+        }
+
+        .lwa-panel-side.lwa-panel-collapsed {
+            transform: translateX(100%);
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        /* Side toggle button - fixed position so it stays visible */
+        .lwa-side-toggle {
+            position: fixed;
+            right: 400px;
+            top: 50%;
+            transform: translateY(-50%);
+            width: 28px;
+            height: 80px;
+            background: linear-gradient(180deg, #2a2a2a 0%, #1a1a1a 100%);
+            border-radius: 6px 0 0 6px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            z-index: 1001;
+            transition: right 0.3s ease, background 0.15s;
+            box-shadow: -3px 0 10px rgba(0,0,0,0.4);
+            border: 1px solid rgba(255,255,255,0.1);
+            border-right: none;
+        }
+
+        .lwa-side-toggle:hover {
+            background: linear-gradient(180deg, #3a3a3a 0%, #2a2a2a 100%);
+        }
+
+        .lwa-side-toggle i {
+            color: #5fad1b;
+            font-size: 28px;
+        }
+
+        .lwa-side-toggle.lwa-toggle-collapsed {
+            right: 0;
+        }
+
+        /* Adjust side panel header for compact display */
+        .lwa-panel-side .panel .header h2 {
+            font-size: 14px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .lwa-panel-side .panel .header .version {
+            display: none;
+        }
+
+        .lwa-panel-side .panel .content {
+            padding: 10px;
+        }
+
+        /* Responsive adjustments for side mode */
+        @media (max-width: 1400px) {
+            .lwa-panel-side {
+                width: 350px;
+            }
+            .lwa-side-toggle {
+                right: 350px;
+            }
+            .lwa-side-toggle.lwa-toggle-collapsed {
+                right: 0;
+            }
+        }
+
+        @media (max-width: 1100px) {
+            .lwa-panel-side {
+                width: 300px;
+            }
+            .lwa-side-toggle {
+                right: 300px;
+            }
+            .lwa-side-toggle.lwa-toggle-collapsed {
+                right: 0;
+            }
+        }
+
+        @media (max-width: 900px) {
+            .lwa-panel-side {
+                position: relative !important;
+                width: 100%;
+                height: auto;
+                max-height: none;
+                top: auto;
+            }
+            .lwa-panel-side .panel {
+                border-radius: 4px;
+            }
+            .lwa-panel-side.lwa-panel-collapsed {
+                transform: translateY(-100%);
+                height: 0;
+            }
+            .lwa-side-toggle {
+                position: relative;
+                right: auto;
+                top: auto;
+                transform: none;
+                width: 100%;
+                height: 32px;
+                border-radius: 4px;
+                margin-bottom: 8px;
+            }
+            .lwa-side-toggle.lwa-toggle-collapsed {
+                right: auto;
+            }
+        }
+
+        .lwa-report-link {
+            color: #5fad1b;
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .lwa-report-link:hover {
+            text-decoration: underline;
+        }
+
+        /* ===== CACHE MODAL ===== */
+        .lwa-cache-modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0,0,0,0.6);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 10000;
+        }
+
+        .lwa-cache-modal-content {
+            background: var(--background, #fff);
+            border-radius: 8px;
+            width: 90%;
+            max-width: 550px;
+            max-height: 85vh;
+            display: flex;
+            flex-direction: column;
+            box-shadow: 0 10px 40px rgba(0,0,0,0.3);
+            overflow: hidden;
+        }
+
+        .lwa-cache-modal-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 14px 18px;
+            background: #2a2a2a;
+            color: #ffffff;
+            font-weight: 600;
+            font-size: 15px;
+        }
+
+        .lwa-cache-modal-header button {
+            background: transparent;
+            border: none;
+            color: #ffffff;
+            font-size: 18px;
+            cursor: pointer;
+            padding: 4px 8px;
+            border-radius: 3px;
+        }
+
+        .lwa-cache-modal-header button:hover {
+            background: rgba(255,255,255,0.2);
+        }
+
+        .lwa-cache-modal-body {
+            padding: 16px;
+            overflow-y: auto;
+        }
+
+        /* Cache Stats */
+        .lwa-cache-stats {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+
+        .lwa-cache-stat {
+            background: var(--background-header, #f5f5f5);
+            border-radius: 6px;
+            padding: 14px;
+            text-align: center;
+            border: 1px solid var(--border, #ddd);
+        }
+
+        .lwa-cache-stat-val {
+            font-size: 22px;
+            font-weight: 700;
+            color: #5fad1b;
+        }
+
+        .lwa-cache-stat-lbl {
+            font-size: 11px;
+            color: var(--text-color-secondary, #666);
+            margin-top: 4px;
+        }
+
+        /* Cache Sections */
+        .lwa-cache-section {
+            background: var(--pure-white, #fff);
+            border: 1px solid var(--border, #ddd);
+            border-radius: 6px;
+            padding: 14px;
+            margin-bottom: 12px;
+        }
+
+        .lwa-cache-section-title {
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--text-color, #333);
+            margin-bottom: 12px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid var(--border, #ddd);
+        }
+
+        /* Cache Settings */
+        .lwa-cache-setting {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        .lwa-cache-setting label {
+            font-size: 12px;
+            color: var(--text-color, #333);
+        }
+
+        .lwa-cache-setting input {
+            width: 80px;
+            padding: 6px 10px;
+            border: 1px solid var(--border, #ddd);
+            border-radius: 4px;
+            font-size: 13px;
+            background: var(--background, #fff);
+            color: var(--text-color, #333);
+        }
+
+        .lwa-btn-small {
+            background: #5fad1b;
+            border: none;
+            color: #fff;
+            padding: 6px 12px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 12px;
+            font-weight: 500;
+            transition: all 0.15s;
+        }
+
+        .lwa-btn-small:hover {
+            background: #6ec91f;
+        }
+
+        /* Cache Actions */
+        .lwa-cache-actions {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        .lwa-btn-action {
+            flex: 1;
+            min-width: 140px;
+            background: var(--background-header, #f5f5f5);
+            border: 1px solid var(--border, #ddd);
+            color: var(--text-color, #333);
+            padding: 10px 14px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 12px;
+            font-weight: 500;
+            transition: all 0.15s;
+        }
+
+        .lwa-btn-action:hover {
+            background: #5fad1b;
+            color: #fff;
+            border-color: #5fad1b;
+        }
+
+        .lwa-btn-action.danger:hover {
+            background: #e22424;
+            border-color: #e22424;
+        }
+
+        /* Cache List */
+        .lwa-cache-list {
+            max-height: 250px;
+            overflow-y: auto;
+        }
+
+        .lwa-cache-empty {
+            text-align: center;
+            padding: 20px;
+            color: var(--text-color-secondary, #666);
+            font-size: 13px;
+        }
+
+        .lwa-cache-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 10px 12px;
+            margin: 4px 0;
+            background: var(--background-header, #f5f5f5);
+            border-radius: 4px;
+            border-left: 3px solid #5fad1b;
+            transition: all 0.15s;
+        }
+
+        .lwa-cache-item:hover {
+            border-left-color: #32b2da;
+        }
+
+        .lwa-cache-item-info {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
+
+        .lwa-cache-item-id {
+            font-weight: 600;
+            font-size: 12px;
+            color: #5fad1b;
+            text-decoration: none;
+        }
+
+        .lwa-cache-item-id:hover {
+            text-decoration: underline;
+        }
+
+        .lwa-cache-item-date {
+            font-size: 11px;
+            color: var(--text-color-secondary, #666);
+        }
+
+        .lwa-cache-item-age {
+            font-size: 10px;
+            color: #888;
+        }
+
+        .lwa-cache-item-actions {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .lwa-cache-item-size {
+            font-size: 10px;
+            color: #888;
+            font-family: monospace;
+        }
+
+        .lwa-cache-item-delete {
+            background: transparent;
+            border: none;
+            cursor: pointer;
+            font-size: 14px;
+            padding: 4px;
+            border-radius: 3px;
+            opacity: 0.6;
+            transition: all 0.15s;
+        }
+
+        .lwa-cache-item-delete:hover {
+            opacity: 1;
+            background: rgba(226,36,36,0.1);
         }
     `;
 


### PR DESCRIPTION
- Add localStorage cache for fight logs (auto-saved on report page)
- Add collapsible side panel on fight pages with responsive resize
- Add toggle button to switch panel position (side/bottom)
- Add cache management modal with cleanup and settings
- Add navigation button from report to fight page
- Reduce retry attempts (2 max, 1s delay) for faster loading
- Update README with new features documentation