### PR TITLE
Add UnifiedMCTS as default algorithm, remove ops estimates

### DIFF
--- a/AI/AI
+++ b/AI/AI
@@ -2,12 +2,13 @@
  * AI - Main entry point and utilities for combo search
  *
  * Algorithm selection: set AI.mode in main before calling AI.getCombo()
- * Example: AI.mode = AI.MODE_HYBRID_GUIDED
+ * Example: AI.mode = AI.MODE_UNIFIED_MCTS
  *
  * See AI/Algorithms/ for algorithm implementations:
  *   - PTS: Fast greedy target-first
  *   - MCTS: Monte Carlo Tree Search
  *   - BeamSearch: Beam search multi-path
+ *   - UnifiedMCTS: Single tree with cells as first-level (recommended)
  *   - Hybrid: Combines PTS with other algorithms
  */
 class AI {
@@ -16,12 +17,12 @@ class AI {
 	static integer MODE_MCTS = 1          // Monte Carlo Tree Search (thorough, slower)
 	static integer MODE_BEAM = 2          // Beam Search (balanced speed/quality)
 	static integer MODE_HYBRID = 3        // PTS seeds MCTS at one cell
-	static integer MODE_HYBRID_GUIDED = 4 // PTS guides MCTS cell order (recommended)
+	static integer MODE_HYBRID_GUIDED = 4 // PTS guides MCTS cell order
 	static integer MODE_HYBRID_BEAM = 5   // PTS guides Beam Search cell order
-	static integer MODE_UNIFIED_MCTS = 6  // Unified MCTS with cell selection in tree
+	static integer MODE_UNIFIED_MCTS = 6  // Unified MCTS with cell selection in tree (recommended)
 
 	// Current mode (default value, can be overridden in main)
-	static integer mode = AI.MODE_HYBRID_GUIDED
+	static integer mode = AI.MODE_UNIFIED_MCTS
 
 	/*
 	 * Get readable name for a mode (for debugging)

--- a/AI/Algorithms/Hybrid
+++ b/AI/Algorithms/Hybrid
@@ -6,8 +6,10 @@
  *
  * Available strategies:
  * - HYBRID: PTS seeds MCTS at one cell
- * - HYBRID_GUIDED: PTS guides MCTS cell order (recommended)
+ * - HYBRID_GUIDED: PTS guides MCTS cell order
  * - HYBRID_BEAM: PTS guides BeamSearch cell order
+ *
+ * Note: UNIFIED_MCTS is now the recommended algorithm (see AI/Algorithms/UnifiedMCTS)
  */
 class Hybrid {
 

--- a/main
+++ b/main
@@ -3,13 +3,13 @@ include('auto');
 // ╔══════════════════════════════════════════════════════════════════════════╗
 // ║                         ALGORITHM CONFIGURATION                          ║
 // ╠══════════════════════════════════════════════════════════════════════════╣
-// ║  MODE_PTS           Fast greedy, target-first (~50k ops)                 ║
-// ║  MODE_MCTS          Full tree search (~300k ops)                         ║
-// ║  MODE_BEAM          Multi-path beam search (~150k ops)                   ║
-// ║  MODE_HYBRID        PTS seeds MCTS on 1 cell (~150k ops)                 ║
-// ║  MODE_HYBRID_GUIDED PTS guides MCTS cell order (~250k ops) [RECOMMENDED] ║
-// ║  MODE_HYBRID_BEAM   PTS guides BeamSearch (~200k ops)                    ║
-// ║  MODE_UNIFIED_MCTS  Single tree with cells as first-level (~300k ops)    ║
+// ║  MODE_PTS           Fast greedy, target-first                            ║
+// ║  MODE_MCTS          Full tree search                                     ║
+// ║  MODE_BEAM          Multi-path beam search                               ║
+// ║  MODE_HYBRID        PTS seeds MCTS on 1 cell                             ║
+// ║  MODE_HYBRID_GUIDED PTS guides MCTS cell order                           ║
+// ║  MODE_HYBRID_BEAM   PTS guides BeamSearch                                ║
+// ║  MODE_UNIFIED_MCTS  Single tree with cells as first-level [RECOMMENDED]  ║
 // ╚══════════════════════════════════════════════════════════════════════════╝
 AI.mode = AI.MODE_UNIFIED_MCTS
 

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,10 @@ tagadalive/
 ├── AI/
 │   ├── AI                # Façade et dispatcher de mode
 │   ├── Algorithms/       # Algorithmes de recherche
-│   │   ├── PTS           # Priority Target Simulation (greedy, ~50k ops)
-│   │   ├── MCTS          # Monte Carlo Tree Search (~300k ops)
-│   │   ├── BeamSearch    # Recherche en faisceau (~150k ops)
+│   │   ├── PTS           # Priority Target Simulation (greedy)
+│   │   ├── MCTS          # Monte Carlo Tree Search
+│   │   ├── BeamSearch    # Recherche en faisceau
+│   │   ├── UnifiedMCTS   # MCTS unifié (cellules au 1er niveau) [DEFAULT]
 │   │   └── Hybrid        # Modes hybrides (combinaisons)
 │   ├── Scoring           # Système de scoring
 │   ├── ScoringConfig     # Constantes ML-tunable


### PR DESCRIPTION
- Set MODE_UNIFIED_MCTS as recommended/default algorithm
- Update AI/AI header and mode comments
- Remove inaccurate "~XXXk ops" from algorithm descriptions
- Add reference to UnifiedMCTS in Hybrid header