### PR TITLE
Tampermonkey: Add cooldown tracking panel

### DIFF
--- a/Services/Benchmark
+++ b/Services/Benchmark
@@ -59,6 +59,10 @@ class Benchmark{
 	static Array<string> _logs = []
 	static _maxLogs = 20
 
+	// Cooldowns tracking: array of [itemName, currentCD, maxCD]
+	static Array<Array> _cooldownsStart = []
+	static Array<Array> _cooldownsEnd = []
+
 	// === Profiling ===
 
 	static void reset(){
@@ -126,6 +130,8 @@ class Benchmark{
 		_comboPosScore = []
 		_comboActScore = []
 		_logs = []
+		_cooldownsStart = []
+		_cooldownsEnd = []
 		_selfLife = getLife()
 		_selfMaxLife = getTotalLife(getEntity())
 		_selfTP = getTP()
@@ -236,6 +242,26 @@ class Benchmark{
 		if(count(_logs) < _maxLogs) push(_logs, "💀" + target)
 	}
 
+	// === Cooldowns tracking ===
+
+	static void collectCooldownsStart(Array<Item> items, integer entityId) {
+		_cooldownsStart = []
+		for (Item item in items) {
+			if (!item.haveCD) continue
+			integer cd = getCooldown(item.id, entityId)
+			push(_cooldownsStart, [item.name, cd, item.cdDuration])
+		}
+	}
+
+	static void collectCooldownsEnd(Array<Item> items, integer entityId) {
+		_cooldownsEnd = []
+		for (Item item in items) {
+			if (!item.haveCD) continue
+			integer cd = getCooldown(item.id, entityId)
+			push(_cooldownsEnd, [item.name, cd, item.cdDuration])
+		}
+	}
+
 	// === Display: ONE debug() call ===
 
 	// Category definitions for grouped display
@@ -329,6 +355,24 @@ class Benchmark{
 		}
 
 		for(var i = 0; i < count(_logs); i++) s += "|l:" + _logs[i]
+
+		// Cooldowns start of turn: cds:name,current,max;...
+		if (count(_cooldownsStart) > 0) {
+			var cdParts = []
+			for (var cd in _cooldownsStart) {
+				push(cdParts, cd[0] + "," + cd[1] + "," + cd[2])
+			}
+			s += "|cds:" + join(cdParts, ";")
+		}
+
+		// Cooldowns end of turn: cde:name,current,max;...
+		if (count(_cooldownsEnd) > 0) {
+			var cdParts = []
+			for (var cd in _cooldownsEnd) {
+				push(cdParts, cd[0] + "," + cd[1] + "," + cd[2])
+			}
+			s += "|cde:" + join(cdParts, ";")
+		}
 
 		// Display ops and final total
 		var displayOps = getOperations() - displayStart

--- a/main
+++ b/main
@@ -16,11 +16,17 @@ AI.mode = AI.MODE_UNIFIED_MCTS
 // Initialize game state
 init()
 
+// Collect cooldowns at START of turn (before actions)
+Benchmark.collectCooldownsStart(Fight.self.items, Fight.self.id)
+
 // Get best combo using selected algorithm
 Combo combo = AI.getCombo()
 
 // Execute the combo
 combo.play()
+
+// Collect cooldowns at END of turn (after actions)
+Benchmark.collectCooldownsEnd(Fight.self.items, Fight.self.id)
 
 // Output debug data (choose one):
 // - display()     : JSON format for Tampermonkey panel

--- a/readme.md
+++ b/readme.md
@@ -34,14 +34,14 @@ tagadalive/
 
 Configurable dans `main` via `AI.mode = AI.MODE_*` :
 
-| Mode | Description | Ops typiques |
-|------|-------------|--------------|
-| `MODE_PTS` | Greedy target-first | ~50k |
-| `MODE_MCTS` | Tree search avec UCB1 | ~300k |
-| `MODE_BEAM` | Multi-path beam search | ~150k |
-| `MODE_HYBRID` | PTS → MCTS sur 1 cellule | ~150k |
-| `MODE_HYBRID_GUIDED` | PTS guide MCTS (recommandé) | ~250k |
-| `MODE_HYBRID_BEAM` | PTS guide BeamSearch | ~200k |
+| Mode | Description |
+|------|-------------|
+| `MODE_PTS` | Greedy target-first |
+| `MODE_MCTS` | Tree search avec UCB1 |
+| `MODE_BEAM` | Multi-path beam search |
+| `MODE_HYBRID` | PTS → MCTS sur 1 cellule |
+| `MODE_HYBRID_GUIDED` | PTS guide MCTS (recommandé) |
+| `MODE_HYBRID_BEAM` | PTS guide BeamSearch |
 
 **Mode par défaut** : `HYBRID_GUIDED`
 

--- a/tampermonkey/README.md
+++ b/tampermonkey/README.md
@@ -6,6 +6,7 @@ A modular Tampermonkey userscript that provides AI debug visualization, profiler
 
 - **Turn-by-turn navigation**: Browse through each turn of your AI's execution
 - **Performance profiler**: See operation counts and percentages for each function, grouped by category
+- **Cooldown tracking**: View item cooldowns at start and end of each turn with visual progress bars
 - **Algorithm visualization**: Adapts to selected mode:
   - **MCTS**: iterations, nodes explored, positions, best score
   - **BeamSearch**: depth, candidates evaluated, positions, best score
@@ -159,6 +160,8 @@ Where:
 | `cells:` | MCTS cells (seeds;explored;skipped) | `cells:123,456;123,456,789;234,567` |
 | `ch:` | Chosen combo (score,actions,desc) | `ch:850,3,Flash(81)->mv(256:...)` |
 | `cb:` | Top combo (score,actScore,posScore,desc) | `cb:900,600,300,Spark(120)->...` |
+| `cds:` | Cooldowns at start of turn (name,current,max;...) | `cds:Flash,0,3;Shield,2,5` |
+| `cde:` | Cooldowns at end of turn (name,current,max;...) | `cde:Flash,3,3;Shield,2,5` |
 | `cat:` | Function category | `cat:MCTS` |
 | `f:` | Function stats (name,calls,total,pct,parent) | `f:AI.search,10,5000,11,` |
 | `l:` | Log entry | `l:Attack dealt 150 damage` |
@@ -213,6 +216,26 @@ Benchmark.log("Custom message")
 Benchmark.logWarn("Warning!")
 Benchmark.logError("Error occurred")
 ```
+
+### Tracking Cooldowns
+
+```javascript
+// At start of turn (after init)
+Benchmark.collectCooldownsStart(Fight.self.items, Fight.self.id)
+
+// At end of turn (after combo.play())
+Benchmark.collectCooldownsEnd(Fight.self.items, Fight.self.id)
+```
+
+The cooldowns panel shows:
+- **Start of turn**: Item availability before actions (green = ready to use)
+- **End of turn**: Item state after actions (shows newly triggered cooldowns)
+
+Color coding:
+- 🟢 Green: Available (cooldown = 0)
+- 🟡 Yellow: 1 turn remaining
+- 🟠 Orange: 2 turns remaining
+- 🔴 Red: 3+ turns remaining
 
 ### Tracking Algorithm Decisions
 
@@ -287,7 +310,8 @@ Benchmark.addCombo(totalScore, actionCount, description, positionScore, actionSc
 - `createPanel()` - Panel creation
 - `injectPanel()` - Panel injection (bottom or side mode)
 - `render()` - Main render function
-- `renderOverview()` - Overview tab
+- `renderOverview()` - Overview tab (includes cooldowns section)
+- `renderCooldownsList()` - Cooldown items with progress bars
 - `renderCombos()` - Combos tab
 - `renderProfiler()` - Profiler tab
 - `renderLogs()` - Logs tab

--- a/tampermonkey/lwa-parser.user.js
+++ b/tampermonkey/lwa-parser.user.js
@@ -271,6 +271,8 @@
             combos: [],
             methods: [],
             logs: [],
+            cooldownsStart: [],
+            cooldownsEnd: [],
             funcCount: 0,
             displayOps: 0
         };
@@ -408,6 +410,36 @@
             else if (p.startsWith('l:')) {
                 turn.logs.push(p.substring(2));
             }
+            else if (p.startsWith('cds:')) {
+                // Format: cds:name,current,max;... (start of turn)
+                const cdItems = p.substring(4).split(';');
+                for (const cdItem of cdItems) {
+                    if (!cdItem) continue;
+                    const parts = cdItem.split(',');
+                    if (parts.length >= 3) {
+                        turn.cooldownsStart.push({
+                            name: parts[0],
+                            current: parseInt(parts[1]) || 0,
+                            max: parseInt(parts[2]) || 0
+                        });
+                    }
+                }
+            }
+            else if (p.startsWith('cde:')) {
+                // Format: cde:name,current,max;... (end of turn)
+                const cdItems = p.substring(4).split(';');
+                for (const cdItem of cdItems) {
+                    if (!cdItem) continue;
+                    const parts = cdItem.split(',');
+                    if (parts.length >= 3) {
+                        turn.cooldownsEnd.push({
+                            name: parts[0],
+                            current: parseInt(parts[1]) || 0,
+                            max: parseInt(parts[2]) || 0
+                        });
+                    }
+                }
+            }
             // Legacy format support
             else if (p.startsWith('ops:')) {
                 const m = p.match(/ops:(\d+)\/(\d+)/);
@@ -494,7 +526,9 @@
                     avg: Math.round(m[1] / m[2]),
                     pct: 0
                 })),
-                logs: d.logs || []
+                logs: d.logs || [],
+                cooldownsStart: (d.cooldownsStart || []).map(c => ({ name: c.name, current: c.current, max: c.max })),
+                cooldownsEnd: (d.cooldownsEnd || []).map(c => ({ name: c.name, current: c.current, max: c.max }))
             };
         } catch (e) {
             return null;

--- a/tampermonkey/lwa-styles.user.js
+++ b/tampermonkey/lwa-styles.user.js
@@ -556,6 +556,206 @@
             border: 1px solid var(--border, #ddd);
         }
 
+        /* ===== COOLDOWNS ===== */
+        .lwa-cooldowns-section {
+            background: var(--background-header, #f5f5f5);
+            border-radius: 4px;
+            padding: 10px;
+        }
+
+        .lwa-cd-tabs {
+            display: flex;
+            gap: 4px;
+            margin-bottom: 10px;
+        }
+
+        .lwa-cd-tab {
+            flex: 1;
+            padding: 6px 12px;
+            border: none;
+            background: var(--pure-white, #fff);
+            border: 1px solid var(--border, #ddd);
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--text-color-secondary, #666);
+            transition: all 0.15s;
+        }
+
+        .lwa-cd-tab:hover {
+            background: #f0f0f0;
+        }
+
+        .lwa-cd-tab.active {
+            background: #5fad1b;
+            color: #fff;
+            border-color: #5fad1b;
+        }
+
+        .lwa-cd-tab-content {
+            display: none;
+        }
+
+        .lwa-cd-tab-content.active {
+            display: block;
+        }
+
+        .lwa-cd-empty {
+            text-align: center;
+            color: var(--text-color-secondary, #666);
+            font-size: 12px;
+            padding: 12px;
+        }
+
+        .lwa-cd-count {
+            font-size: 11px;
+            background: rgba(255, 136, 0, 0.2);
+            color: #ff8800;
+            padding: 2px 6px;
+            border-radius: 10px;
+            margin-left: 6px;
+        }
+
+        .lwa-cooldowns-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .lwa-cooldown-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 10px;
+            background: var(--pure-white, #fff);
+            border-radius: 4px;
+            border: 1px solid var(--border, #ddd);
+            border-left: 3px solid #e22424;
+            min-width: 140px;
+            flex: 1 1 140px;
+            max-width: 200px;
+        }
+
+        .lwa-cooldown-item.almost {
+            border-left-color: #ff8800;
+        }
+
+        .lwa-cooldown-item.soon {
+            border-left-color: #f0c040;
+        }
+
+        .lwa-cooldown-item.ready {
+            border-left-color: #5fad1b;
+            background: rgba(95, 173, 27, 0.08);
+        }
+
+        .lwa-cd-icon {
+            width: 22px;
+            height: 22px;
+            border-radius: 50%;
+            background: #e22424;
+            color: #fff;
+            font-size: 11px;
+            font-weight: 700;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-shrink: 0;
+        }
+
+        .lwa-cooldown-item.almost .lwa-cd-icon {
+            background: #ff8800;
+        }
+
+        .lwa-cooldown-item.soon .lwa-cd-icon {
+            background: #f0c040;
+            color: #333;
+        }
+
+        .lwa-cooldown-item.ready .lwa-cd-icon {
+            background: #5fad1b;
+            font-size: 12px;
+        }
+
+        .lwa-cd-name {
+            font-weight: 600;
+            font-size: 11px;
+            color: var(--text-color, #333);
+            flex: 1;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .lwa-cd-bar-container {
+            width: 40px;
+            flex-shrink: 0;
+        }
+
+        .lwa-cd-bar {
+            height: 4px;
+            background: #ddd;
+            border-radius: 2px;
+            overflow: hidden;
+        }
+
+        .lwa-cd-fill {
+            height: 100%;
+            background: #e22424;
+            border-radius: 2px;
+            transition: width 0.3s ease;
+        }
+
+        .lwa-cd-fill.almost {
+            background: #ff8800;
+        }
+
+        .lwa-cd-fill.soon {
+            background: #f0c040;
+        }
+
+        .lwa-cd-fill.ready {
+            background: #5fad1b;
+        }
+
+        /* Légende */
+        .lwa-cd-legend {
+            display: flex;
+            gap: 12px;
+            margin-top: 10px;
+            padding-top: 8px;
+            border-top: 1px solid var(--border, #ddd);
+            justify-content: center;
+        }
+
+        .lwa-cd-legend-item {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 10px;
+            color: var(--text-color-secondary, #666);
+        }
+
+        .lwa-cd-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #e22424;
+        }
+
+        .lwa-cd-legend-item.ready .lwa-cd-dot {
+            background: #5fad1b;
+        }
+
+        .lwa-cd-legend-item.soon .lwa-cd-dot {
+            background: #f0c040;
+        }
+
+        .lwa-cd-legend-item.almost .lwa-cd-dot {
+            background: #ff8800;
+        }
+
         /* ===== AGGREGATED STATS ===== */
         .lwa-agg-grid {
             display: grid;


### PR DESCRIPTION
Display item cooldowns in Overview tab with start/end of turn tabs:
- collectCooldownsStart() called after init() for pre-action state
- collectCooldownsEnd() called after combo.play() for post-action state
- Color-coded status: green (ready), yellow (1 turn), orange (2), red (3+)
- Sorted by cooldown (ready items first)
- Visual progress bars and legend