### PR TITLE
Fix chest power

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 concis
+/.vs

--- a/Controlers/Fight
+++ b/Controlers/Fight
@@ -11,6 +11,7 @@ class Fight {
 	private static Map<integer, Entity> _aliveEnemiesBulbs
 	private static Map<integer, Entity> _aliveAlliesLeeks
 	private static Map<integer, Entity> _aliveAlliesBulbs
+	static Map<string, integer> chestPwrGained = ["wood_chest":10, "iron_chest":50, "diamond_chest":100]
 	static Array<integer> allEntitiesId
 	static Entity self
 	static Cell selfCell = Cell(Cell.SELF_CAST_ID)

--- a/Model/Combos/Consequences
+++ b/Model/Combos/Consequences
@@ -158,15 +158,10 @@ class Consequences {
 		}
 		// Chest power gain (all fight types): 50% pwr + type bonus (wood +10, iron +50, diamond +100)
 		if(entity.entityType == ENTITY_CHEST) {
-			integer chestBonus = 0
-			if(entity.name == "wood_chest") chestBonus = 10
-			else if(entity.name == "iron_chest") chestBonus = 50
-			else if(entity.name == "diamond_chest") chestBonus = 100
-			integer pwrGain = chestBonus + round(entity.pwr * 0.5)
-			this.add(Fight.self, Stats.PWR, pwrGain)
+			this.add(Fight.self, Stats.PWR, Fight.chestPwrGained[entity.name])
 		}
 		// BR power gain (leek = 10 + 50% pwr, bulb = 2 + 50% pwr)
-		else if(Fight.isBattleRoyale) {
+		if(Fight.isBattleRoyale) {
 			integer basePwr = entity.isBulb ? 2 : 10
 			integer pwrGain = basePwr + round(entity.pwr * 0.5)
 			this.add(Fight.self, Stats.PWR, pwrGain)

--- a/Model/Combos/Consequences
+++ b/Model/Combos/Consequences
@@ -156,11 +156,11 @@ class Consequences {
 			integer tpGain = round(passives[EFFECT_KILL_TO_TP]!)
 			if(tpGain > 0) this.add(Fight.self, Stats.TP, tpGain)
 		}
-		// Chest power gain (all fight types): 50% pwr + type bonus (wood +10, iron +50, diamond +100)
+		// Chest power gain (all fight types): wood +10, iron +50, diamond +100
 		if(entity.entityType == ENTITY_CHEST) {
 			this.add(Fight.self, Stats.PWR, Fight.chestPwrGained[entity.name])
 		}
-		// BR power gain (leek = 10 + 50% pwr, bulb = 2 + 50% pwr)
+		// BR power gain (leek/chest = 10 + 50% pwr, bulb = 2 + 50% pwr)
 		if(Fight.isBattleRoyale) {
 			integer basePwr = entity.isBulb ? 2 : 10
 			integer pwrGain = basePwr + round(entity.pwr * 0.5)


### PR DESCRIPTION
Correction de la puissance données par les coffres dans tous les type de combats qui ne dépend que du type de coffre.
Un bonus supplémentaire peut être donné pour un coffre en BR mais lui ne dépend pas du type de coffre.
Ajout d'un dictionnaire pour avoir le gain par type de coffre plutôt qu'une suite de if else.