### PR TITLE
Enhance Tampermonkey CalibratedPTS display and MCTS combo tracking

### DIFF
--- a/AI/Algorithms/CalibratedPTS
+++ b/AI/Algorithms/CalibratedPTS
@@ -79,6 +79,13 @@ class CalibratedPTS {
 			CalibratedPTS.bestCombo != null ? count(CalibratedPTS.bestCombo!.actions) : 0,
 			CalibratedPTS.bestScore)
 
+		// Log calibration-specific stats
+		Benchmark.setCalibration(CalibratedPTS.lastBestBudget, CalibratedPTS.mpValue,
+			CalibratedPTS.lastCalibrationPoints)
+
+		// Log top calibration combos for the Combos tab
+		CalibratedPTS.logCalibrationCombos()
+
 		Benchmark.stop("CalibratedPTS.calibrate")
 	}
 
@@ -300,5 +307,27 @@ class CalibratedPTS {
 		}
 		if (desc == "") desc = "stay"
 		return desc
+	}
+
+	/*
+	 * Log calibration combos to Benchmark for the Combos tab
+	 * Logs up to 5 best combos from different budgets
+	 */
+	static void logCalibrationCombos() {
+		// Sort by total score descending, then by budget ascending (lower MP first when tied)
+		Array<CalibrationPoint> sorted = arraySort(CalibratedPTS.curve, (a, b) -> {
+			if (a.totalScore != b.totalScore) return a.totalScore < b.totalScore ? 1 : -1
+			return a.budgetRequested > b.budgetRequested ? 1 : -1
+		}) as Array<CalibrationPoint>
+
+		integer logged = 0
+		for (CalibrationPoint p in sorted) {
+			if (logged >= 5) break
+			if (count(p.combo.actions) == 0 && p.positionScore <= 0) continue
+
+			string desc = "CAL[MP" + p.budgetRequested + "]:" + CalibratedPTS.buildComboDesc(p.combo)
+			Benchmark.addCombo(p.totalScore, count(p.combo.actions), desc, p.positionScore, p.actionScore)
+			logged++
+		}
 	}
 }

--- a/AI/Algorithms/CellMCTS
+++ b/AI/Algorithms/CellMCTS
@@ -360,6 +360,12 @@ class CellMCTS {
 		Combo mctsCombo = CellMCTS.extractBestCombo(root)
 		real mctsScore = mctsCombo.getScore()!
 
+		// Log MCTS combo to alternatives list
+		real mctsActScore = 0
+		for (Action a in mctsCombo.actions) mctsActScore += a.score!
+		real mctsPosScore = mctsCombo.finalPosition != null ? mctsCombo.finalPosition!.score : 0
+		Benchmark.setMCTSCombo(mctsScore, count(mctsCombo.actions), "MCTS:" + CellMCTS.buildComboDesc(mctsCombo), mctsPosScore, mctsActScore)
+
 		Benchmark.setMCTS(iterations, nodesCreated, movesExplored, mctsScore)
 		Benchmark.stop("CellMCTS.run")
 

--- a/AI/Algorithms/MCTS
+++ b/AI/Algorithms/MCTS
@@ -245,7 +245,7 @@ class MCTS {
 		real actScore = 0
 		for (Action a in combo.actions) actScore += a.score!
 		real posScore = combo.finalPosition ? combo.finalPosition!.score : 0
-		Benchmark.addCombo(combo.getScore()!, count(combo.actions), MCTS.buildComboDesc(combo), posScore, actScore)
+		Benchmark.setMCTSCombo(combo.getScore()!, count(combo.actions), "MCTS:" + MCTS.buildComboDesc(combo), posScore, actScore)
 
 		return combo
 	}

--- a/AI/Algorithms/OpportunityMCTS
+++ b/AI/Algorithms/OpportunityMCTS
@@ -236,6 +236,12 @@ class OpportunityMCTS {
 		Combo mctsCombo = OpportunityMCTS.extractBestCombo(root)
 		real mctsScore = mctsCombo.getScore()!
 
+		// Log MCTS combo to alternatives list
+		real mctsActScore = 0
+		for (Action a in mctsCombo.actions) mctsActScore += a.score!
+		real mctsPosScore = mctsCombo.finalPosition != null ? mctsCombo.finalPosition!.score : 0
+		Benchmark.setMCTSCombo(mctsScore, count(mctsCombo.actions), "MCTS:" + OpportunityMCTS.buildComboDesc(mctsCombo), mctsPosScore, mctsActScore)
+
 		Benchmark.setMCTS(iterations, nodesCreated, 0, mctsScore)
 		Benchmark.stop("OpportunityMCTS.run")
 

--- a/AI/Algorithms/UnifiedMCTS
+++ b/AI/Algorithms/UnifiedMCTS
@@ -270,6 +270,12 @@ class UnifiedMCTS {
 		Combo mctsCombo = UnifiedMCTS.extractBestCombo(root)
 		real mctsScore = mctsCombo.getScore()!
 
+		// Log MCTS combo to alternatives list
+		real mctsActScore = 0
+		for (Action a in mctsCombo.actions) mctsActScore += a.score!
+		real mctsPosScore = mctsCombo.finalPosition != null ? mctsCombo.finalPosition!.score : 0
+		Benchmark.setMCTSCombo(mctsScore, count(mctsCombo.actions), "MCTS:" + UnifiedMCTS.buildComboDesc(mctsCombo), mctsPosScore, mctsActScore)
+
 		Benchmark.setMCTS(iterations, nodesCreated, cellsExplored, mctsScore)
 		Benchmark.stop("UnifiedMCTS.run")
 

--- a/Services/Benchmark
+++ b/Services/Benchmark
@@ -30,6 +30,10 @@ class Benchmark{
 	// Algorithm comparison
 	static _algoMode = ""
 	static _algoWinner = ""
+	// Calibration stats (CalibratedPTS)
+	static _calBudget = ""
+	static _calMpValue = 0
+	static _calPoints = 0
 	// MCTS cells tracking
 	static Array<integer> _mctsSeeds = []      // Priority cells from PTS
 	static Array<integer> _mctsExplored = []   // Cells actually explored
@@ -55,6 +59,13 @@ class Benchmark{
 	static Array<integer> _comboActions = []
 	static Array<integer> _comboPosScore = []
 	static Array<integer> _comboActScore = []
+
+	// MCTS best combo (separate from top 5 to always show it)
+	static _mctsComboDesc = ""
+	static _mctsComboScore = 0
+	static _mctsComboActions = 0
+	static _mctsComboPosScore = 0
+	static _mctsComboActScore = 0
 
 	static Array<string> _logs = []
 	static _maxLogs = 20
@@ -118,6 +129,9 @@ class Benchmark{
 		_beamBudgetLow = false
 		_algoMode = ""
 		_algoWinner = ""
+		_calBudget = ""
+		_calMpValue = 0
+		_calPoints = 0
 		_mctsSeeds = []
 		_mctsExplored = []
 		_mctsSkipped = []
@@ -129,6 +143,11 @@ class Benchmark{
 		_comboActions = []
 		_comboPosScore = []
 		_comboActScore = []
+		_mctsComboDesc = ""
+		_mctsComboScore = 0
+		_mctsComboActions = 0
+		_mctsComboPosScore = 0
+		_mctsComboActScore = 0
 		_logs = []
 		_cooldownsStart = []
 		_cooldownsEnd = []
@@ -191,6 +210,12 @@ class Benchmark{
 		_algoWinner = winner
 	}
 
+	static void setCalibration(string bestBudget, real mpValue, integer points){
+		_calBudget = bestBudget
+		_calMpValue = round(mpValue)
+		_calPoints = points
+	}
+
 	static void setMCTSCells(Array<Cell> seeds, Array<Cell> explored, Array<Cell> skipped){
 		_mctsSeeds = []
 		_mctsExplored = []
@@ -206,20 +231,44 @@ class Benchmark{
 		_chosenDesc = desc
 	}
 
+	static void setMCTSCombo(real score, integer actions, string desc, real posScore, real actScore){
+		_mctsComboScore = round(score)
+		_mctsComboActions = actions
+		_mctsComboDesc = desc
+		_mctsComboPosScore = round(posScore)
+		_mctsComboActScore = round(actScore)
+	}
+
 	static void addCombo(real score, integer actions, string desc, real posScore, real actScore){
-		var s = round(score)
-		if(count(_comboScore) < _maxCombos){
-			push(_comboDesc, desc)
+		integer s = round(score)
+		integer ps = round(posScore)
+		integer acts = round(actScore)
+
+		if (count(_comboScore) < _maxCombos) {
+			// Room available, just add
 			push(_comboScore, s)
+			push(_comboDesc, desc)
 			push(_comboActions, actions)
-			push(_comboPosScore, round(posScore))
-			push(_comboActScore, round(actScore))
-		} else if(s > _comboScore[_maxCombos - 1]){
-			_comboDesc[_maxCombos - 1] = desc
-			_comboScore[_maxCombos - 1] = s
-			_comboActions[_maxCombos - 1] = actions
-			_comboPosScore[_maxCombos - 1] = round(posScore)
-			_comboActScore[_maxCombos - 1] = round(actScore)
+			push(_comboPosScore, ps)
+			push(_comboActScore, acts)
+		} else {
+			// Find index of minimum score
+			integer minIdx = 0
+			integer minScore = _comboScore[0]
+			for (integer i = 1; i < _maxCombos; i++) {
+				if (_comboScore[i] < minScore) {
+					minScore = _comboScore[i]
+					minIdx = i
+				}
+			}
+			// Replace if new score is better
+			if (s > minScore) {
+				_comboScore[minIdx] = s
+				_comboDesc[minIdx] = desc
+				_comboActions[minIdx] = actions
+				_comboPosScore[minIdx] = ps
+				_comboActScore[minIdx] = acts
+			}
 		}
 	}
 
@@ -268,7 +317,7 @@ class Benchmark{
 	static Array<Array<string>> CATEGORIES = [
 		["INIT", "init", "Map.init", "Items.init"],
 		["REFRESH", "MapPath.refresh", "Fight.refresh", "Map.refresh", "Scoring.refresh", "MapDanger.refresh", "MapPosition.refresh", "MapAction.refresh", "MapOpportunity.refresh"],
-		["PTS", "PTS.buildCombo"],
+		["PTS", "PTS.buildCombo", "CalibratedPTS.calibrate", "CalibratedPTS.buildWithBudget"],
 		["MCTS", "MCTS.iter", "Hybrid.runMCTSFull", "Hybrid.runMCTSPrioritized", "Hybrid.getMCTSSeeded", "Hybrid.getMCTSGuided"],
 		["BEAM", "BeamSearch.search", "Hybrid.runBeamFull", "Hybrid.runBeamPrioritized", "Hybrid.getBeamGuided"],
 		["POSITION", "MP.evalPos", "MP.findBest"],
@@ -308,6 +357,7 @@ class Benchmark{
 		s += "|p:" + _ptsOpps + "," + _ptsActions + "," + _ptsBest
 		s += "|b:" + _beamDepth + "," + _beamCandidates + "," + _beamOpsExpand + "," + _beamOpsSort + "," + _beamOpsPos + "," + _beamOpsTotal + "," + _beamBest + "," + (_beamBudgetLow ? 1 : 0)
 		if(_algoMode != "") s += "|algo:" + _algoMode + "," + _algoWinner
+		if(_calBudget != "") s += "|cal:" + _calBudget + "," + _calMpValue + "," + _calPoints
 		s += "|fc:" + funcCount  // Function count for verification
 
 		// MCTS cells: seeds, explored, skipped
@@ -320,6 +370,9 @@ class Benchmark{
 		for(var i = 0; i < count(_comboScore); i++){
 			s += "|cb:" + _comboScore[i] + "," + _comboActScore[i] + "," + _comboPosScore[i] + "," + _comboDesc[i]
 		}
+
+		// MCTS best combo (always shown separately)
+		if(_mctsComboDesc != "") s += "|mcb:" + _mctsComboScore + "," + _mctsComboActScore + "," + _mctsComboPosScore + "," + _mctsComboDesc
 
 		// Group functions by category
 		Map<string, Array<Array>> catFuncs = [:]

--- a/tampermonkey/lwa-charts.user.js
+++ b/tampermonkey/lwa-charts.user.js
@@ -949,20 +949,46 @@
                 </div>
             </div>
 
-            ${(stats.ptsWins > 0 || stats.mctsWins > 0) ? `
+            ${(stats.ptsWins > 0 || stats.mctsWins > 0) ? (() => {
+                const totalWins = stats.ptsWins + stats.mctsWins + stats.beamWins;
+                const ptsPct = totalWins > 0 ? Math.round(stats.ptsWins * 100 / totalWins) : 0;
+                const mctsPct = totalWins > 0 ? Math.round(stats.mctsWins * 100 / totalWins) : 0;
+                const beamPct = totalWins > 0 ? Math.round(stats.beamWins * 100 / totalWins) : 0;
+                const leader = stats.ptsWins > stats.mctsWins ? 'PTS' : stats.mctsWins > stats.ptsWins ? 'MCTS' : 'TIE';
+                return `
             <div class="lwa-section">
-                <div class="lwa-section-title">Algorithm Comparison (PTS vs MCTS)</div>
+                <div class="lwa-section-title">Algorithm Wins</div>
+
+                <!-- Ratio Banner -->
+                <div style="display:flex;align-items:center;justify-content:center;gap:12px;margin-bottom:16px;padding:12px;background:${C.cardBg};border-radius:8px">
+                    <span style="font-size:24px;font-weight:700;color:#2bc491">${stats.ptsWins}</span>
+                    <span style="font-size:14px;color:${C.textDim}">PTS</span>
+                    <span style="font-size:18px;color:${C.textDim}">vs</span>
+                    <span style="font-size:14px;color:${C.textDim}">MCTS</span>
+                    <span style="font-size:24px;font-weight:700;color:${C.orange}">${stats.mctsWins}</span>
+                    ${stats.beamWins > 0 ? `
+                    <span style="font-size:18px;color:${C.textDim}">vs</span>
+                    <span style="font-size:14px;color:${C.textDim}">BEAM</span>
+                    <span style="font-size:24px;font-weight:700;color:${C.purple}">${stats.beamWins}</span>
+                    ` : ''}
+                </div>
+
+                <!-- Visual Comparison Bar -->
+                <div style="margin-bottom:16px">
+                    <div style="display:flex;height:28px;border-radius:6px;overflow:hidden;background:${C.border}">
+                        ${stats.ptsWins > 0 ? `<div style="width:${ptsPct}%;background:#2bc491;display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;font-size:12px">${ptsPct}%</div>` : ''}
+                        ${stats.mctsWins > 0 ? `<div style="width:${mctsPct}%;background:${C.orange};display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;font-size:12px">${mctsPct}%</div>` : ''}
+                        ${stats.beamWins > 0 ? `<div style="width:${beamPct}%;background:${C.purple};display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;font-size:12px">${beamPct}%</div>` : ''}
+                    </div>
+                    <div style="display:flex;justify-content:space-between;margin-top:4px;font-size:11px;color:${C.textDim}">
+                        <span style="color:#2bc491">PTS ${ptsPct}%</span>
+                        ${stats.beamWins > 0 ? `<span style="color:${C.purple}">BEAM ${beamPct}%</span>` : ''}
+                        <span style="color:${C.orange}">MCTS ${mctsPct}%</span>
+                    </div>
+                </div>
+
+                <!-- Score Comparison -->
                 <div class="lwa-agg-grid">
-                    <div class="lwa-agg-card ${stats.ptsWins > stats.mctsWins ? 'good' : ''}">
-                        <div class="lwa-agg-val" style="color:#2bc491">${stats.ptsWins}</div>
-                        <div class="lwa-agg-lbl">PTS Wins</div>
-                        <div class="lwa-agg-desc">${pct(stats.ptsWins, stats.totalTurns)}%</div>
-                    </div>
-                    <div class="lwa-agg-card ${stats.mctsWins > stats.ptsWins ? 'good' : ''}">
-                        <div class="lwa-agg-val" style="color:${C.orange}">${stats.mctsWins}</div>
-                        <div class="lwa-agg-lbl">MCTS Wins</div>
-                        <div class="lwa-agg-desc">${pct(stats.mctsWins, stats.totalTurns)}%</div>
-                    </div>
                     <div class="lwa-agg-card">
                         <div class="lwa-agg-val" style="color:#2bc491">${stats.avgPtsScore}</div>
                         <div class="lwa-agg-lbl">Avg PTS Score</div>
@@ -971,9 +997,16 @@
                         <div class="lwa-agg-val" style="color:${C.orange}">${stats.avgMctsScore}</div>
                         <div class="lwa-agg-lbl">Avg MCTS Score</div>
                     </div>
+                    ${stats.beamWins > 0 ? `
+                    <div class="lwa-agg-card">
+                        <div class="lwa-agg-val" style="color:${C.purple}">${stats.avgBeamScore || 0}</div>
+                        <div class="lwa-agg-lbl">Avg BEAM Score</div>
+                    </div>
+                    ` : ''}
                 </div>
             </div>
-            ` : ''}
+            `})()
+            : ''}
 
             ${topMethods.length > 0 ? `
             <div class="lwa-section">

--- a/tampermonkey/lwa-parser.user.js
+++ b/tampermonkey/lwa-parser.user.js
@@ -266,9 +266,11 @@
             pts: { opps: 0, actions: 0, best: 0 },
             beam: { depth: 0, candidates: 0, opsExpand: 0, opsSort: 0, opsPos: 0, opsTotal: 0, best: 0, budgetLow: false },
             algo: { mode: '', winner: '' },
+            calibration: { bestBudget: '', mpValue: 0, points: 0 },
             cells: { seeds: [], explored: [], skipped: [] },
             chosen: { score: 0, actions: 0, desc: '' },
             combos: [],
+            mctsCombo: null,  // Best MCTS combo (separate from top 5)
             methods: [],
             logs: [],
             cooldownsStart: [],
@@ -353,6 +355,13 @@
                 turn.algo.mode = vals[0] || '';
                 turn.algo.winner = vals[1] || '';
             }
+            else if (p.startsWith('cal:')) {
+                // Format: cal:bestBudget,mpValue,points (e.g., cal:MP3,85,6)
+                const vals = p.substring(4).split(',');
+                turn.calibration.bestBudget = vals[0] || '';
+                turn.calibration.mpValue = parseInt(vals[1]) || 0;
+                turn.calibration.points = parseInt(vals[2]) || 0;
+            }
             else if (p.startsWith('cells:')) {
                 // Format: cells:seeds;explored;skipped (each is comma-separated cell IDs)
                 const groups = p.substring(6).split(';');
@@ -378,6 +387,17 @@
                         ps: parseInt(m[3]),
                         d: m[4]
                     });
+                }
+            }
+            else if (p.startsWith('mcb:')) {
+                const m = p.match(/mcb:(-?\d+),(-?\d+),(-?\d+),(.+)/);
+                if (m) {
+                    turn.mctsCombo = {
+                        s: parseInt(m[1]),
+                        as: parseInt(m[2]),
+                        ps: parseInt(m[3]),
+                        d: m[4]
+                    };
                 }
             }
             else if (p.startsWith('cat:')) {

--- a/tampermonkey/lwa-styles.user.js
+++ b/tampermonkey/lwa-styles.user.js
@@ -366,6 +366,15 @@
             color: var(--text-color, #333);
         }
 
+        .lwa-algo-winscore {
+            font-size: 16px;
+            font-weight: 700;
+            color: var(--text-color, #333);
+            padding: 2px 8px;
+            background: rgba(255,255,255,0.3);
+            border-radius: 4px;
+        }
+
         .lwa-algo-arrow {
             color: var(--text-color-secondary, #666);
         }
@@ -498,6 +507,10 @@
         .lwa-combo-source.mcts {
             background: rgba(255, 136, 0, 0.2);
             color: #ff8800;
+        }
+        .lwa-combo-source.cal {
+            background: rgba(160, 23, 214, 0.2);
+            color: #a017d6;
         }
 
         /* Ops Progress */


### PR DESCRIPTION
LeekScript:
- Add setMCTSCombo() in Benchmark for dedicated MCTS combo display
- Sort calibration combos by budget when scores are tied (best budget first)
- Output MCTS combo via |mcb: field separate from top 5

Tampermonkey:
- Parse and display MCTS best combo in dedicated section below top 5
- Add PTS vs MCTS win ratio (e.g., 2-5) in overview banner
- Improve MP Value display: green (Stay), red (Move!), gray (neutral)
- Add detailed tooltips explaining mpValue meaning
- Remove Operations Used from overview (already in Analysis tab)